### PR TITLE
fix cron job creator

### DIFF
--- a/src/Form/StanfordMigrateUltimateCronForm.php
+++ b/src/Form/StanfordMigrateUltimateCronForm.php
@@ -5,7 +5,6 @@ namespace Drupal\stanford_migrate\Form;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\migrate\Plugin\MigrationPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/src/Form/StanfordMigrateUltimateCronForm.php
+++ b/src/Form/StanfordMigrateUltimateCronForm.php
@@ -16,13 +16,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class StanfordMigrateUltimateCronForm extends FormBase {
 
   /**
-   * Migration plugin manager service.
-   *
-   * @var \Drupal\migrate\Plugin\MigrationPluginManager
-   */
-  protected $migrationManager;
-
-  /**
    * Entity type manager service.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -34,7 +27,6 @@ class StanfordMigrateUltimateCronForm extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('plugin.manager.migration'),
       $container->get('entity_type.manager')
     );
   }
@@ -42,13 +34,10 @@ class StanfordMigrateUltimateCronForm extends FormBase {
   /**
    * StanfordMigrateUltimateCronForm constructor.
    *
-   * @param \Drupal\migrate\Plugin\MigrationPluginManager $migration_manager
-   *   Migration plugin manager service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager service.
    */
-  public function __construct(MigrationPluginManager $migration_manager, EntityTypeManagerInterface $entity_type_manager) {
-    $this->migrationManager = $migration_manager;
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }
 
@@ -68,7 +57,6 @@ class StanfordMigrateUltimateCronForm extends FormBase {
 
     $existing_migration_jobs = [];
     $missing_migration_jobs = [];
-
 
     $migration_group_configs = $this->configFactory->listAll('migrate_plus.migration_group.');
     foreach ($migration_group_configs as $config_name) {

--- a/stanford_migrate.links.task.yml
+++ b/stanford_migrate.links.task.yml
@@ -1,0 +1,4 @@
+stanford_migrate.ultimate_cron:
+  title: 'Migrations'
+  route_name: stanford_migrate.ultimate_cron
+  base_route: entity.ultimate_cron_job.collection

--- a/stanford_migrate.routing.yml
+++ b/stanford_migrate.routing.yml
@@ -9,7 +9,7 @@ stanford_migrate.list:
     _custom_access: '\Drupal\stanford_migrate\Form\StanfordMigrateImportForm::access'
 
 stanford_migrate.ultimate_cron:
-  path: '/admin/config/importers/ultimate-cron'
+  path: '/admin/config/system/cron/migrate-jobs'
   defaults:
     _form: '\Drupal\stanford_migrate\Form\StanfordMigrateUltimateCronForm'
     _title: 'Importer Cron Jobs'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Create an ultimate cron job using the migration group instead of the migration id.
- moved the cron job creator form to the cron area of the toolbar.

# Need Review By (Date)
- 6/25

# Urgency
- low

# Steps to Test
1. delete all ultimate cron stanford_migrate cron jobs `rm config/sync/ultimate_cron.job.stanford_migrate_*`
1. import config
1. go to the cron job form `/admin/config/system/cron/migrate-jobs`
1. create the missing cron jobs
1. export config and validate the jobs exist

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
