### PR TITLE
Dont run migrations during site install

### DIFF
--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -14,6 +14,7 @@ use Drupal\migrate_tools\MigrateExecutable;
 use Drupal\migrate\MigrateMessage;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\ultimate_cron\CronJobInterface;
+use Drupal\Core\Installer\InstallerKernel;
 
 /**
  * Implements hook_help().
@@ -116,6 +117,11 @@ function stanford_migrate_entity_delete(EntityInterface $entity) {
  *   Ultimate cron entity.
  */
 function stanford_migrate_ultimate_cron_task(CronJobInterface $cron_entity) {
+
+  // Don't run the migrations when drupal is being installed.
+  if (InstallerKernel::installationAttempted()) {
+    return;
+  }
   // Invalidate migration plugins to gather any changes to config entities
   // before running import. This allows for any changes to the source urls.
   Cache::invalidateTags(['migration_plugins']);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- What the title sayz

# Need Review By (Date)
- soon would be nice.

# Urgency
- medium high

# Steps to Test
1. checkout this branch
1. do a site install
1. verify the migrations weren't ran. this is easiest to see with drush 10.3.1 like it is for gryphon stack.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
