### PR TITLE
Filter out null entity ids

### DIFF
--- a/src/EventSubscriber/EventsSubscriber.php
+++ b/src/EventSubscriber/EventsSubscriber.php
@@ -107,10 +107,11 @@ class EventsSubscriber implements EventSubscriberInterface {
       if (!$id_exists_in_source) {
         // Find the entity id from the id map.
         $destination_ids = $id_map->lookupDestinationIds($id_map->currentSource());
+        $destination_ids = array_filter(reset($destination_ids));
 
         /** @var \Drupal\Core\Entity\ContentEntityInterface[] $entities */
         // $destination_ids should be a single item.
-        $entities = $entity_storage->loadMultiple(reset($destination_ids));
+        $entities = $entity_storage->loadMultiple($destination_ids);
 
         switch ($orphan_action) {
           case self::ORPHAN_DELETE:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If the migration skipped an item, the destination IDs will be `null` so we will want to prevent loading an array of `null` values

# Need Review By (Date)
- 9/3

# Urgency
- medium

# Steps to Test
1. Create a migration that skips some items
1. import so that some entities are created.
1. change the source to remove the entities in the feed
1. run the importer and verify no php notices like `array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:266` 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
