### PR TITLE
Fixed orphan actions

### DIFF
--- a/src/EventSubscriber/EventsSubscriber.php
+++ b/src/EventSubscriber/EventsSubscriber.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\stanford_migrate\EventSubscriber;
 
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\migrate\Event\MigrateEvents;
 use Drupal\migrate\Event\MigrateImportEvent;
@@ -42,11 +44,19 @@ class EventsSubscriber implements EventSubscriberInterface {
   protected $logger;
 
   /**
+   * Default cache service.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
+
+  /**
    * Constructs a new MigrateEventsSubscriber object.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerChannelFactory $logger_factory) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerChannelFactory $logger_factory, CacheBackendInterface $cache) {
     $this->entityTypeManager = $entity_type_manager;
     $this->logger = $logger_factory->get('stanford_migrate');
+    $this->cache = $cache;
   }
 
   /**
@@ -66,10 +76,10 @@ class EventsSubscriber implements EventSubscriberInterface {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\Core\Entity\EntityStorageException
-   * @throws \Drupal\migrate\MigrateException
    */
   public function postImport(MigrateImportEvent $event) {
     $orphan_action = $this->getOrphanAction($event->getMigration());
+
     // Migration doesn't have a orphan action, ignore it.
     if (!$orphan_action) {
       return;
@@ -119,44 +129,53 @@ class EventsSubscriber implements EventSubscriberInterface {
       // it.
       if (!$id_exists_in_source) {
         // Find the entity id from the id map.
-        $destination_ids = $id_map->lookupDestinationIds($id_map->currentSource());
-        $destination_ids = array_filter(reset($destination_ids));
+        $destination_id = $id_map->lookupDestinationIds($id_map->currentSource());
 
-        /** @var \Drupal\Core\Entity\ContentEntityInterface[] $entities */
-        // $destination_ids should be a single item.
-        $entities = $entity_storage->loadMultiple($destination_ids);
+        // $destination_id should be a single entity id.
+        while (is_array($destination_id)) {
+          $destination_id = reset($destination_id);
+        }
+
+        if (!$destination_id) {
+          continue;
+        }
+        /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+        $entity = $entity_storage->load($destination_id);
+        if (!$entity) {
+          continue;
+        }
 
         switch ($orphan_action) {
           case self::ORPHAN_DELETE:
-            foreach ($entities as $entity) {
-              $this->logger->notice($this->t('Deleted entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
-                '@migration' => $event->getMigration()->label(),
-                '@entity_type' => $type,
-                '@label' => $entity->label(),
-              ]);
-            }
+            $this->logger->notice($this->t('Deleted entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
+              '@migration' => $event->getMigration()->label(),
+              '@entity_type' => $type,
+              '@label' => $entity->label(),
+            ]);
 
             // Delete the entity, then the record in the id map.
-            $entity_storage->delete($entities);
+            $entity->delete();
             break;
 
           case self::ORPHAN_UNPUBLISH:
-            // Unpublish the orphans.
-            foreach ($entities as $entity) {
-              if ($entity->hasField($status_key)) {
-                $entity->setNewRevision();
-                if ($entity->hasField('revision_log')) {
-                  $entity->set('revision_log', 'Unpublished content since it no longer exists in the source data');
-                }
-                $entity->set($status_key, 0)->save();
+            // Unpublish the orphan only if it is currently published.
+            if (
+              $entity->hasField($status_key) &&
+              $entity->get($status_key)->getString()
+            ) {
+              $entity->setNewRevision();
+              if ($entity->hasField('revision_log')) {
+                $entity->set('revision_log', 'Unpublished content since it no longer exists in the source data');
               }
-
-              $this->logger->notice($this->t('Unpublished entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
-                '@migration' => $event->getMigration()->label(),
-                '@entity_type' => $type,
-                '@label' => $entity->label(),
-              ]);
+              $entity->set($status_key, 0)->save();
             }
+
+            $this->logger->notice($this->t('Unpublished entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
+              '@migration' => $event->getMigration()->label(),
+              '@entity_type' => $type,
+              '@label' => $entity->label(),
+            ]);
+
             break;
         }
       }
@@ -164,6 +183,8 @@ class EventsSubscriber implements EventSubscriberInterface {
       // Move on to the next existing item.
       $id_map->next();
     }
+
+
   }
 
   /**
@@ -184,6 +205,19 @@ class EventsSubscriber implements EventSubscriberInterface {
 
       // @see \Drupal\stanford_migrate\Plugin\migrate\source\StanfordUrl::getAllIds()
       if (method_exists($migration->getSourcePlugin(), 'getAllIds')) {
+
+        $cid = 'stanford_migrate:' . $migration->id();
+        // No need to check the contents of the cache. The cache is just a
+        // temporary flag that the orphan action has recently occurred. This
+        // will prevent the unnecessary double execution.
+        if ($this->cache->get($cid)) {
+          return FALSE;
+        }
+
+        // Just set a cache that expires in 5 minutes. This will allow us to
+        // just check if the cache exists so that we don't have to run the
+        // orphan action more than 1 time.
+        $this->cache->set($cid, time(), time() + 60 + 5);
         return $source_config['orphan_action'];
       }
     }

--- a/src/EventSubscriber/EventsSubscriber.php
+++ b/src/EventSubscriber/EventsSubscriber.php
@@ -84,7 +84,6 @@ class EventsSubscriber implements EventSubscriberInterface {
     if (!$orphan_action) {
       return;
     }
-    var_dump(__LINE__);
 
     /** @var \Drupal\stanford_migrate\Plugin\migrate\source\StanfordUrl $source_plugin */
     $source_plugin = $event->getMigration()->getSourcePlugin();

--- a/src/EventSubscriber/EventsSubscriber.php
+++ b/src/EventSubscriber/EventsSubscriber.php
@@ -167,14 +167,13 @@ class EventsSubscriber implements EventSubscriberInterface {
                 $entity->set('revision_log', 'Unpublished content since it no longer exists in the source data');
               }
               $entity->set($status_key, 0)->save();
+
+              $this->logger->notice($this->t('Unpublished entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
+                '@migration' => $event->getMigration()->label(),
+                '@entity_type' => $type,
+                '@label' => $entity->label(),
+              ]);
             }
-
-            $this->logger->notice($this->t('Unpublished entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
-              '@migration' => $event->getMigration()->label(),
-              '@entity_type' => $type,
-              '@label' => $entity->label(),
-            ]);
-
             break;
         }
       }

--- a/src/EventSubscriber/EventsSubscriber.php
+++ b/src/EventSubscriber/EventsSubscriber.php
@@ -74,6 +74,7 @@ class EventsSubscriber implements EventSubscriberInterface {
     if (!$orphan_action) {
       return;
     }
+    var_dump(__LINE__);
 
     /** @var \Drupal\stanford_migrate\Plugin\migrate\source\StanfordUrl $source_plugin */
     $source_plugin = $event->getMigration()->getSourcePlugin();
@@ -129,8 +130,7 @@ class EventsSubscriber implements EventSubscriberInterface {
           case self::ORPHAN_DELETE:
             foreach ($entities as $entity) {
               $this->logger->notice($this->t('Deleted entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
-                '@migration' => $event->getMigration()
-                  ->label(),
+                '@migration' => $event->getMigration()->label(),
                 '@entity_type' => $type,
                 '@label' => $entity->label(),
               ]);
@@ -152,8 +152,7 @@ class EventsSubscriber implements EventSubscriberInterface {
               }
 
               $this->logger->notice($this->t('Unpublished entity since it no longer exists in the source data. Migration: @migration, Entity Type: @entity_type, Label: @label'), [
-                '@migration' => $event->getMigration()
-                  ->label(),
+                '@migration' => $event->getMigration()->label(),
                 '@entity_type' => $type,
                 '@label' => $entity->label(),
               ]);

--- a/src/EventSubscriber/EventsSubscriber.php
+++ b/src/EventSubscriber/EventsSubscriber.php
@@ -181,8 +181,6 @@ class EventsSubscriber implements EventSubscriberInterface {
       // Move on to the next existing item.
       $id_map->next();
     }
-
-
   }
 
   /**

--- a/stanford_migrate.services.yml
+++ b/stanford_migrate.services.yml
@@ -1,6 +1,6 @@
 services:
   stanford_migrate.event_subscriber:
     class: Drupal\stanford_migrate\EventSubscriber\EventsSubscriber
-    arguments: ['@entity_type.manager', '@logger.factory']
+    arguments: ['@entity_type.manager', '@logger.factory', '@cache.default']
     tags:
       - { name: event_subscriber }

--- a/stanford_migrate.services.yml
+++ b/stanford_migrate.services.yml
@@ -1,6 +1,6 @@
 services:
   stanford_migrate.event_subscriber:
     class: Drupal\stanford_migrate\EventSubscriber\EventsSubscriber
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@logger.factory']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed logic when there are more than 1 `destid` columns. Those are used for `destid1` => entity id. `destid2` => revision id. we don't want to load the entity that has the same id as another revision id.
- Improved performance by only running one time instead of multiple.

# Need Review By (Date)
- asap

# Urgency
- 

# Steps to Test

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
