### PR TITLE
"8.x-1.x 8.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Stanford Migrate
 
+8.x-1.7
+--------------------------------------------------------------------------------
+_Release Date: 2020-12-04_
+
+- Change constructor argument to accept the interface instead of the class (0bb3732)
+- Use the latest migrate_file (#22) (b52b31b)
+- phpunit void return annoation (1fb7697)
+- D9 Readiness (#21) (8d40220)
+
 8.x-1.6
 --------------------------------------------------------------------------------
 _Release Date: 2020-11-06_

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "drupal/migrate_file": "^1.1",
+        "drupal/migrate_file": "^2.0",
         "drupal/migrate_plus": "^5.0",
         "drupal/migrate_tools": "^5.0",
         "drupal/ultimate_cron": "^2.0@alpha"

--- a/src/EventSubscriber/EventsSubscriber.php
+++ b/src/EventSubscriber/EventsSubscriber.php
@@ -3,7 +3,7 @@
 namespace Drupal\stanford_migrate\EventSubscriber;
 
 use Drupal\Core\Cache\CacheBackendInterface;
-use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\migrate\Event\MigrateEvents;
 use Drupal\migrate\Event\MigrateImportEvent;
@@ -54,12 +54,12 @@ class EventsSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager service.
-   * @param \Drupal\Core\Logger\LoggerChannelFactory $logger_factory
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   Logger factory service.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   Default cache service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerChannelFactory $logger_factory, CacheBackendInterface $cache) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerChannelFactoryInterface $logger_factory, CacheBackendInterface $cache) {
     $this->entityTypeManager = $entity_type_manager;
     $this->logger = $logger_factory->get('stanford_migrate');
     $this->cache = $cache;

--- a/stanford_migrate.info.yml
+++ b/stanford_migrate.info.yml
@@ -3,7 +3,7 @@ description: 'Adds more functionality to migrate and migrate plus modules'
 type: module
 core_version_requirement: ^8.8 || ^9
 package: 'Stanford'
-version: 8.x-1.7-dev
+version: 8.x-1.7
 dependencies:
   - drupal:migrate
   - migrate_plus:migrate_plus

--- a/stanford_migrate.info.yml
+++ b/stanford_migrate.info.yml
@@ -3,7 +3,7 @@ description: 'Adds more functionality to migrate and migrate plus modules'
 type: module
 core_version_requirement: ^8.8 || ^9
 package: 'Stanford'
-version: 8.x-1.6
+version: 8.x-1.7-dev
 dependencies:
   - drupal:migrate
   - migrate_plus:migrate_plus

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -79,9 +79,9 @@ function stanford_migrate_entity_delete(EntityInterface $entity) {
   $manager = \Drupal::service('plugin.manager.migration');
   $migrations = $manager->createInstances([]);
 
-  /** @var \Drupal\migrate_plus\Entity\Migration $migration */
+  /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
   foreach ($migrations as $migration) {
-    $destination = $migration->get('destination');
+    $destination = $migration->getDestinationConfiguration();
 
     // It should always be set. but its just a safety valve.
     if (!isset($destination['plugin'])) {

--- a/tests/src/Kernel/EventSubscriber/EventsSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/EventsSubscriberTest.php
@@ -10,7 +10,7 @@ class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     \Drupal::configFactory()
       ->getEditable('migrate_plus.migration.stanford_migrate')

--- a/tests/src/Kernel/Form/StanfordMigrateImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateImportFormTest.php
@@ -21,7 +21,7 @@ class StanfordMigrateImportFormTest extends StanfordMigrateKernelTestBase {
   /**
    * {@inheritDoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     \Drupal::configFactory()
       ->getEditable('migrate_plus.migration.stanford_migrate')

--- a/tests/src/Kernel/StanfordMigrateKernelTestBase.php
+++ b/tests/src/Kernel/StanfordMigrateKernelTestBase.php
@@ -27,7 +27,7 @@ abstract class StanfordMigrateKernelTestBase extends KernelTestBase {
   /**
    * {@inheritDoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('user');

--- a/tests/src/Unit/Plugin/migrate_plus/data_parser/DataParserTestBase.php
+++ b/tests/src/Unit/Plugin/migrate_plus/data_parser/DataParserTestBase.php
@@ -23,7 +23,7 @@ abstract class DataParserTestBase extends UnitTestCase {
   /**
    * {@inheritDoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 $this->dataFetcherContent =
     $data_fetcher = $this->createMock(DataFetcherPluginInterface::class);

--- a/tests/src/Unit/StanfordMigratePermissionsTest.php
+++ b/tests/src/Unit/StanfordMigratePermissionsTest.php
@@ -19,7 +19,7 @@ class StanfordMigratePermissionsTest extends UnitTestCase {
   /**
    * {@inheritDoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $migration = $this->createMock(Migration::class);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Automated pull request created via HAL 9000.  See changes below for details.

# Review By (Date)
- As soon as possible


The following changes since commit 13984cf4254ab16da8002b8a9aeb8e43099a4d68:

  8.1.6 (2020-11-09 08:57:44 -0800)

are available in the Git repository at:

  ./ 

for you to fetch changes up to 81dc69dc451320dd76dacd68857715c4d276a579:

  8.1.7 (2020-12-04 12:06:03 -0700)

----------------------------------------------------------------
Ian Monroe (1):
      8.1.7

Mike Decker (2):
      phpunit void return annoation
      Change constructor argument to accept the interface instead of the class

pookmish (2):
      D9 Readiness (#21)
      Use the latest migrate_file (#22)

sws-developers@lists.stanford.edu (1):
      Back to dev

 CHANGELOG.md                                                     | 9 +++++++++
 composer.json                                                    | 2 +-
 src/EventSubscriber/EventsSubscriber.php                         | 6 +++---
 stanford_migrate.info.yml                                        | 2 +-
 stanford_migrate.module                                          | 4 ++--
 tests/src/Kernel/EventSubscriber/EventsSubscriberTest.php        | 2 +-
 tests/src/Kernel/Form/StanfordMigrateImportFormTest.php          | 2 +-
 tests/src/Kernel/StanfordMigrateKernelTestBase.php               | 2 +-
 .../Unit/Plugin/migrate_plus/data_parser/DataParserTestBase.php  | 2 +-
 tests/src/Unit/StanfordMigratePermissionsTest.php                | 2 +-
 10 files changed, 21 insertions(+), 12 deletions(-)"