### PR TITLE
HSD8-1025 CSV Importer upload form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "drupal/migrate_tools": "^5.0",
         "drupal/ultimate_cron": "^2.0@alpha"
     },
+    "require-dev": {
+        "drupal/migrate_source_csv": "^3.4"
+    },
     "extra": {
         "patches": {
             "drupal/migrate_plus": {

--- a/src/Config/MigrationConfigOverrides.php
+++ b/src/Config/MigrationConfigOverrides.php
@@ -54,13 +54,13 @@ class MigrationConfigOverrides implements ConfigFactoryOverrideInterface {
         $migration_id = pathinfo($name, PATHINFO_EXTENSION);
 
         // If the state value is not set, don't do any overriding.
-        if ($file_id = $this->state->get("stanford_migrate.csv.$migration_id")) {
+        if ($file_ids = $this->state->get("stanford_migrate.csv.$migration_id", [])) {
           $file_storage = $this->entityTypeManager->getStorage('file');
 
           /** @var \Drupal\file\FileInterface $file */
           // Make sure the file actually exists.
           if (
-            ($file = $file_storage->load($file_id)) &&
+            ($file = $file_storage->load(end($file_ids))) &&
             file_exists($file->getFileUri())
           ) {
             $overrides[$name]['source']['path'] = $file->getFileUri();

--- a/src/Config/MigrationConfigOverrides.php
+++ b/src/Config/MigrationConfigOverrides.php
@@ -59,10 +59,7 @@ class MigrationConfigOverrides implements ConfigFactoryOverrideInterface {
 
           /** @var \Drupal\file\FileInterface $file */
           // Make sure the file actually exists.
-          if (
-            ($file = $file_storage->load(end($file_ids))) &&
-            file_exists($file->getFileUri())
-          ) {
+          if ($file = $file_storage->load(end($file_ids))) {
             $overrides[$name]['source']['path'] = $file->getFileUri();
           }
         }

--- a/src/Config/MigrationConfigOverrides.php
+++ b/src/Config/MigrationConfigOverrides.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\stanford_migrate\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+
+/**
+ * Class MigrationConfigOverrides.
+ *
+ * @package Drupal\stanford_migrate\Config
+ */
+class MigrationConfigOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * Entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Drupal core state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * MigrationConfigOverrides constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager service.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   Drupal core state service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, StateInterface $state) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    foreach ($names as $name) {
+
+      // Only override migration entities.
+      if (substr($name, 0, 23) == 'migrate_plus.migration.') {
+        $migration_id = pathinfo($name, PATHINFO_EXTENSION);
+
+        // If the state value is not set, don't do any overriding.
+        if ($file_id = $this->state->get("stanford_migrate.csv.$migration_id")) {
+          $file_storage = $this->entityTypeManager->getStorage('file');
+
+          /** @var \Drupal\file\FileInterface $file */
+          // Make sure the file actually exists.
+          if (
+            ($file = $file_storage->load($file_id)) &&
+            file_exists($file->getFileUri())
+          ) {
+            $overrides[$name]['source']['path'] = $file->getFileUri();
+          }
+        }
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheSuffix() {
+    return 'MigrationConfigOverrides';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/src/Controller/MigrationCsvTemplate.php
+++ b/src/Controller/MigrationCsvTemplate.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\stanford_migrate\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Drupal\migrate_plus\Entity\Migration as MigrationEntity;
+use Drupal\migrate_plus\Entity\MigrationGroupInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Class MigrationCsvTemplate
+ *
+ * @package Drupal\stanford_migrate\Controller
+ */
+class MigrationCsvTemplate extends ControllerBase {
+
+  /**
+   * Migration plugin manager service.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
+   */
+  protected $migrationManager;
+
+  /**
+   * Core file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.migration'),
+      $container->get('file_system')
+    );
+  }
+
+  /**
+   * MigrationCsvTemplate constructor.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
+   *   Migration plugin manager service.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   Core file system service.
+   */
+  public function __construct(MigrationPluginManagerInterface $migration_manager, FileSystemInterface $file_system) {
+    $this->migrationManager = $migration_manager;
+    $this->fileSystem = $file_system;
+  }
+
+  /**
+   * Get a csv template with a header row for easily populating a datasheet.
+   *
+   * @param \Drupal\migrate_plus\Entity\MigrationGroupInterface $migration_group
+   *   Migration group entity.
+   * @param \Drupal\migrate_plus\Entity\Migration $migration
+   *   Migration config entity, not the migration plugin.
+   *
+   * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+   *   The template csv file with only the header row.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  public function getEmptyTemplate(MigrationGroupInterface $migration_group, MigrationEntity $migration): BinaryFileResponse {
+    /** @var \Drupal\migrate\Plugin\MigrationInterface $migration_plugin */
+    $migration_plugin = $this->migrationManager->createInstance($migration->id());
+
+    // If the migration is not a CSV importer, run a 404 response.
+    if ($migration_plugin->getSourcePlugin()->getPluginId() != 'csv') {
+      throw new NotFoundHttpException();
+    }
+
+    $csv_headers = [];
+    // Build the headers for the csv file.
+    foreach ($migration_plugin->getSourceConfiguration()['fields'] as $source_field) {
+      $csv_headers[] = str_replace(',', '', sprintf('%s (%s)', $source_field['selector'], $source_field['label']));
+    }
+
+    $file_name = $migration->id() . '.csv';
+    $uri = $this->fileSystem->saveData(implode(',', $csv_headers), "temporary://$file_name", FileSystemInterface::EXISTS_REPLACE);
+    $headers = [
+      'Content-Type' => 'text/csv',
+      'Content-Disposition' => 'attachment; filename="' . $file_name . '"',
+    ];
+    // Return the temporary file as a download.
+    return new BinaryFileResponse($uri, 200, $headers, FALSE);
+  }
+
+}

--- a/src/Controller/MigrationCsvTemplate.php
+++ b/src/Controller/MigrationCsvTemplate.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Class MigrationCsvTemplate
+ * Class MigrationCsvTemplate.
  *
  * @package Drupal\stanford_migrate\Controller
  */

--- a/src/Controller/MigrationCsvTemplate.php
+++ b/src/Controller/MigrationCsvTemplate.php
@@ -5,7 +5,6 @@ namespace Drupal\stanford_migrate\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Drupal\migrate_plus\Entity\Migration as MigrationEntity;
-use Drupal\migrate_plus\Entity\MigrationGroupInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/MigrationCsvTemplate.php
+++ b/src/Controller/MigrationCsvTemplate.php
@@ -46,8 +46,6 @@ class MigrationCsvTemplate extends ControllerBase {
   /**
    * Get a csv template with a header row for easily populating a datasheet.
    *
-   * @param \Drupal\migrate_plus\Entity\MigrationGroupInterface $migration_group
-   *   Migration group entity.
    * @param \Drupal\migrate_plus\Entity\Migration $migration
    *   Migration config entity, not the migration plugin.
    *
@@ -56,7 +54,7 @@ class MigrationCsvTemplate extends ControllerBase {
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
-  public function getEmptyTemplate(MigrationGroupInterface $migration_group, MigrationEntity $migration) {
+  public function getEmptyTemplate(MigrationEntity $migration) {
     /** @var \Drupal\migrate\Plugin\MigrationInterface $migration_plugin */
     $migration_plugin = $this->migrationManager->createInstance($migration->id());
 

--- a/src/Form/StanfordMigrateCsvImportForm.php
+++ b/src/Form/StanfordMigrateCsvImportForm.php
@@ -116,8 +116,6 @@ class StanfordMigrateCsvImportForm extends EntityForm {
       '#upload_validators' => ['file_validate_extensions' => ['csv']],
       '#default_value' => array_slice($previously_uploaded_files, -1),
     ];
-    $file = $this->entityTypeManager->getStorage('file')
-      ->load(end($previously_uploaded_files));
 
     if (!count($previously_uploaded_files)) {
       return $form;

--- a/src/Form/StanfordMigrateCsvImportForm.php
+++ b/src/Form/StanfordMigrateCsvImportForm.php
@@ -224,7 +224,7 @@ class StanfordMigrateCsvImportForm extends EntityForm {
       // Remove the file usage tracking on the previously uploaded files.
       $previous_fids = $this->state->get("stanford_migrate.csv.$migration_id", []);
       if ($previous_fids) {
-        foreach ($this->entityTypeManager->getStorage($previous_fids) as $previous_file) {
+        foreach ($this->entityTypeManager->getStorage('file')->loadMultiple($previous_fids) as $previous_file) {
           $this->fileUsage->delete($previous_file, 'stanford_migrate', 'migration', $migration_id);
         }
       }

--- a/src/Form/StanfordMigrateCsvImportForm.php
+++ b/src/Form/StanfordMigrateCsvImportForm.php
@@ -4,7 +4,6 @@ namespace Drupal\stanford_migrate\Form;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -42,20 +41,12 @@ class StanfordMigrateCsvImportForm extends EntityForm {
   protected $state;
 
   /**
-   * Core date formatter service.
-   *
-   * @var \Drupal\Core\Datetime\DateFormatterInterface
-   */
-  protected $dateFormatter;
-
-  /**
    * {@inheritDoc}
    */
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('plugin.manager.migration'),
-      $container->get('state'),
-      $container->get('date.formatter')
+      $container->get('state')
     );
   }
 
@@ -67,10 +58,9 @@ class StanfordMigrateCsvImportForm extends EntityForm {
    * @param \Drupal\Core\State\StateInterface $state
    *   Core state service.
    */
-  public function __construct(MigrationPluginManagerInterface $migration_manager, StateInterface $state, DateFormatterInterface $date_formatter) {
+  public function __construct(MigrationPluginManagerInterface $migration_manager, StateInterface $state) {
     $this->migrationManager = $migration_manager;
     $this->state = $state;
-    $this->dateFormatter = $date_formatter;
 
     /** @var \Drupal\migrate_plus\Entity\MigrationInterface $migration */
     $migration = $this->getRequest()->attributes->get('migration');
@@ -209,7 +199,7 @@ class StanfordMigrateCsvImportForm extends EntityForm {
     if ($form_state::hasAnyErrors()) {
       return;
     }
-    //Invalidate the migration
+    // Invalidate the migration cache since the file is changing.
     Cache::invalidateTags(['migration_plugins']);
     $migration_id = $this->entity->id();
 

--- a/src/Form/StanfordMigrateCsvImportForm.php
+++ b/src/Form/StanfordMigrateCsvImportForm.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\stanford_migrate\Form;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class StanfordMigrateCsvImportForm.
+ *
+ * @package Drupal\stanford_migrate\Form
+ */
+class StanfordMigrateCsvImportForm extends EntityForm {
+
+  /**
+   * Migration plugin manager service.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
+   */
+  protected $migrationManager;
+
+  /**
+   * Migration plugin instance that matches the migration entity.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationInterface
+   */
+  protected $migrationPlugin;
+
+  /**
+   * Core state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Core date formatter service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.migration'),
+      $container->get('state'),
+      $container->get('date.formatter')
+    );
+  }
+
+  /**
+   * StanfordMigrateCsvImportForm constructor.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
+   *   Migration plugin manager service.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   Core state service.
+   */
+  public function __construct(MigrationPluginManagerInterface $migration_manager, StateInterface $state, DateFormatterInterface $date_formatter) {
+    $this->migrationManager = $migration_manager;
+    $this->state = $state;
+    $this->dateFormatter = $date_formatter;
+
+    /** @var \Drupal\migrate_plus\Entity\MigrationInterface $migration */
+    $migration = $this->getRequest()->attributes->get('migration');
+    $this->migrationPlugin = $this->migrationManager->createInstance($migration->id());
+  }
+
+  /**
+   * Check if the user should have access to the form.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Current user.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Allowed if the migration is a csv importer.
+   */
+  public function access(AccountInterface $account): AccessResult {
+    $source_plugin = $this->migrationPlugin->getSourcePlugin();
+    return AccessResult::allowedIf($source_plugin->getPluginId() == 'csv');
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+    $migration_id = $this->entity->id();
+    $form['csv'] = [
+      '#type' => 'managed_file',
+      '#title' => $this->t('CSV File'),
+      '#upload_location' => 'private://csv/',
+      '#upload_validators' => ['file_validate_extensions' => ['csv']],
+      '#default_value' => array_filter([$this->state->get("stanford_migrate.csv.$migration_id")]),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    // Don't save the entity, we'll store the value in state and use it in a
+    // config overrider.
+    $file_id = $form_state->getValue(['csv', 0]);
+    $migration_id = $this->entity->id();
+
+    $max_age = $this->configFactory()
+      ->get('system.file')
+      ->get('temporary_maximum_age');
+    $this->state->delete("stanford_migrate.csv.$migration_id");
+
+    if ($file_id) {
+      $this->state->set("stanford_migrate.csv.$migration_id", $file_id);
+      $this->messenger()
+        ->addStatus($this->t('File temporarily saved. It will be retained for %max_age', ['%max_age' => $this->dateFormatter->formatInterval($max_age)]));
+    }
+  }
+
+}

--- a/src/Form/StanfordMigrateCsvImportForm.php
+++ b/src/Form/StanfordMigrateCsvImportForm.php
@@ -80,7 +80,7 @@ class StanfordMigrateCsvImportForm extends EntityForm {
     $source_plugin = $this->migrationPlugin->getSourcePlugin();
     // If the migration doesn't import csv, there's no reason to allow the form.
     if ($source_plugin->getPluginId() != 'csv') {
-      AccessResult::forbidden();
+      return AccessResult::forbidden();
     }
     $migration_id = $this->migrationPlugin->id();
     return AccessResult::allowedIfHasPermission($account, "import $migration_id migration");

--- a/src/Form/StanfordMigrateCsvImportForm.php
+++ b/src/Form/StanfordMigrateCsvImportForm.php
@@ -3,9 +3,11 @@
 namespace Drupal\stanford_migrate\Form;
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
@@ -95,9 +97,13 @@ class StanfordMigrateCsvImportForm extends EntityForm {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
     $migration_id = $this->entity->id();
+    $link = Link::fromTextAndUrl($this->t('empty CSV template'), $this->entity->toUrl('csv-template'))
+      ->toString();
+
     $form['csv'] = [
       '#type' => 'managed_file',
       '#title' => $this->t('CSV File'),
+      '#description' => $this->t('Download an @link for the importer.', ['@link' => $link]),
       '#upload_location' => 'private://csv/',
       '#upload_validators' => ['file_validate_extensions' => ['csv']],
       '#default_value' => array_filter([$this->state->get("stanford_migrate.csv.$migration_id")]),
@@ -125,6 +131,8 @@ class StanfordMigrateCsvImportForm extends EntityForm {
       $this->messenger()
         ->addStatus($this->t('File temporarily saved. It will be retained for %max_age', ['%max_age' => $this->dateFormatter->formatInterval($max_age)]));
     }
+
+    Cache::invalidateTags(['migration_plugins']);
   }
 
 }

--- a/src/Form/StanfordMigrateCsvImportForm.php
+++ b/src/Form/StanfordMigrateCsvImportForm.php
@@ -223,8 +223,10 @@ class StanfordMigrateCsvImportForm extends EntityForm {
 
       // Remove the file usage tracking on the previously uploaded files.
       $previous_fids = $this->state->get("stanford_migrate.csv.$migration_id", []);
-      foreach ($this->entityTypeManager->getStorage($previous_fids) as $previous_file) {
-        $this->fileUsage->delete($previous_file, 'stanford_migrate', 'migration', $migration_id);
+      if ($previous_fids) {
+        foreach ($this->entityTypeManager->getStorage($previous_fids) as $previous_file) {
+          $this->fileUsage->delete($previous_file, 'stanford_migrate', 'migration', $migration_id);
+        }
       }
       $this->state->delete("stanford_migrate.csv.$migration_id");
     }

--- a/src/Plugin/Derivative/MigrateLocalTasks.php
+++ b/src/Plugin/Derivative/MigrateLocalTasks.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\stanford_migrate\Plugin\Derivative;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class MigrateLocalTasks.
+ *
+ * @package Drupal\stanford_migrate\Plugin\Derivative
+ */
+class MigrateLocalTasks extends DeriverBase implements ContainerDeriverInterface {
+
+  /**
+   * Core module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * MigrateLocalTasks constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   Core module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+    if ($this->moduleHandler->moduleExists('migrate_source_csv')) {
+      $this->derivatives['entity.migration.csv_upload'] = $base_plugin_definition;
+      $this->derivatives['entity.migration.csv_upload']['title'] = 'CSV Upload';
+      $this->derivatives['entity.migration.csv_upload']['route_name'] = 'entity.migration.csv_upload';
+      $this->derivatives['entity.migration.csv_upload']['base_route'] = 'entity.migration.overview';
+    }
+    return parent::getDerivativeDefinitions($base_plugin_definition);
+  }
+
+}

--- a/stanford_migrate.links.task.yml
+++ b/stanford_migrate.links.task.yml
@@ -1,3 +1,6 @@
+stanford_migrate.local_tasks:
+  deriver: 'Drupal\stanford_migrate\Plugin\Derivative\MigrateLocalTasks'
+
 stanford_migrate.ultimate_cron:
   title: 'Migrations'
   route_name: stanford_migrate.ultimate_cron

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -64,6 +64,16 @@ function _stanford_migrate_get_time($arg = NULL) {
 }
 
 /**
+ * Implements hook_entity_type_alter().
+ */
+function stanford_migrate_entity_type_alter(array &$entity_types) {
+  if (\Drupal::moduleHandler()->moduleExists('migrate_source_csv')) {
+    $entity_types['migration']->setFormClass('upload-csv', 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm');
+    $entity_types['migration']->setLinkTemplate('upload-csv', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-upload');
+  }
+}
+
+/**
  * Implements hook_migrate_source_info_alter().
  */
 function stanford_migrate_migrate_source_info_alter(array &$definitions) {

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -68,8 +68,8 @@ function _stanford_migrate_get_time($arg = NULL) {
  */
 function stanford_migrate_entity_type_alter(array &$entity_types) {
   if (\Drupal::moduleHandler()->moduleExists('migrate_source_csv')) {
-    $entity_types['migration']->setFormClass('upload-csv', 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm');
-    $entity_types['migration']->setLinkTemplate('upload-csv', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-upload');
+    $entity_types['migration']->setFormClass('csv-upload', 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm');
+    $entity_types['migration']->setLinkTemplate('csv-upload', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-upload');
     $entity_types['migration']->setLinkTemplate('csv-template', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-template');
   }
 }

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -68,12 +68,18 @@ function _stanford_migrate_get_time($arg = NULL) {
  */
 function stanford_migrate_entity_type_alter(array &$entity_types) {
   if (\Drupal::moduleHandler()->moduleExists('migrate_source_csv')) {
-    /** @var \Drupal\Core\Config\Entity\ConfigEntityType $m */
-//    $m = $entity_types['migration'];
     $entity_types['migration']->setFormClass('upload-csv', 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm');
     $entity_types['migration']->setLinkTemplate('upload-csv', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-upload');
     $entity_types['migration']->setLinkTemplate('csv-template', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-template');
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function stanford_migrate_migration_delete(Migration $entity) {
+  // Clean up the state if the migration is deleted.
+  \Drupal::state()->delete("stanford_migrate.csv.{$entity->id()}");
 }
 
 /**

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -68,8 +68,11 @@ function _stanford_migrate_get_time($arg = NULL) {
  */
 function stanford_migrate_entity_type_alter(array &$entity_types) {
   if (\Drupal::moduleHandler()->moduleExists('migrate_source_csv')) {
+    /** @var \Drupal\Core\Config\Entity\ConfigEntityType $m */
+//    $m = $entity_types['migration'];
     $entity_types['migration']->setFormClass('upload-csv', 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm');
     $entity_types['migration']->setLinkTemplate('upload-csv', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-upload');
+    $entity_types['migration']->setLinkTemplate('csv-template', '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-template');
   }
 }
 

--- a/stanford_migrate.routing.yml
+++ b/stanford_migrate.routing.yml
@@ -32,3 +32,19 @@ entity.migration.csv_upload:
         type: entity:migration
       migration_group:
         type: entity:migration_group
+
+entity.migration.csv_template:
+  path: '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-template'
+  defaults:
+    _controller: '\Drupal\stanford_migrate\Controller\MigrationCsvTemplate::getEmptyTemplate'
+    _title: 'CSV Template'
+    _migrate_group: true
+  requirements:
+    _entity_access: migration.update
+    _module_dependencies: migrate_source_csv
+  options:
+    parameters:
+      migration:
+        type: entity:migration
+      migration_group:
+        type: entity:migration_group

--- a/stanford_migrate.routing.yml
+++ b/stanford_migrate.routing.yml
@@ -33,7 +33,7 @@ entity.migration.csv_upload:
         type: entity:migration_group
 
 entity.migration.csv_template:
-  path: '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-template'
+  path: '/admin/structure/migrate/migrations/{migration}/csv-template'
   defaults:
     _controller: '\Drupal\stanford_migrate\Controller\MigrationCsvTemplate::getEmptyTemplate'
     _title: 'CSV Template'
@@ -45,5 +45,3 @@ entity.migration.csv_template:
     parameters:
       migration:
         type: entity:migration
-      migration_group:
-        type: entity:migration_group

--- a/stanford_migrate.routing.yml
+++ b/stanford_migrate.routing.yml
@@ -24,7 +24,6 @@ entity.migration.csv_upload:
     _migrate_group: true
   requirements:
     _custom_access: 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm::access'
-    _entity_access: migration.update
     _module_dependencies: migrate_source_csv
   options:
     parameters:
@@ -40,7 +39,7 @@ entity.migration.csv_template:
     _title: 'CSV Template'
     _migrate_group: true
   requirements:
-    _entity_access: migration.update
+    _custom_access: 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm::access'
     _module_dependencies: migrate_source_csv
   options:
     parameters:

--- a/stanford_migrate.routing.yml
+++ b/stanford_migrate.routing.yml
@@ -19,7 +19,7 @@ stanford_migrate.ultimate_cron:
 entity.migration.csv_upload:
   path: '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-upload'
   defaults:
-    _entity_form: 'migration.upload-csv'
+    _entity_form: 'migration.csv-upload'
     _title: 'Upload CSV'
     _migrate_group: true
   requirements:

--- a/stanford_migrate.routing.yml
+++ b/stanford_migrate.routing.yml
@@ -37,7 +37,6 @@ entity.migration.csv_template:
   defaults:
     _controller: '\Drupal\stanford_migrate\Controller\MigrationCsvTemplate::getEmptyTemplate'
     _title: 'CSV Template'
-    _migrate_group: true
   requirements:
     _custom_access: 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm::access'
     _module_dependencies: migrate_source_csv

--- a/stanford_migrate.routing.yml
+++ b/stanford_migrate.routing.yml
@@ -15,3 +15,20 @@ stanford_migrate.ultimate_cron:
     _title: 'Importer Cron Jobs'
   requirements:
     _permission: 'administer migrations'
+
+entity.migration.csv_upload:
+  path: '/admin/structure/migrate/manage/{migration_group}/migrations/{migration}/csv-upload'
+  defaults:
+    _entity_form: 'migration.upload-csv'
+    _title: 'Upload CSV'
+    _migrate_group: true
+  requirements:
+    _custom_access: 'Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm::access'
+    _entity_access: migration.update
+    _module_dependencies: migrate_source_csv
+  options:
+    parameters:
+      migration:
+        type: entity:migration
+      migration_group:
+        type: entity:migration_group

--- a/stanford_migrate.services.yml
+++ b/stanford_migrate.services.yml
@@ -4,3 +4,8 @@ services:
     arguments: ['@entity_type.manager', '@logger.factory', '@cache.default']
     tags:
       - { name: event_subscriber }
+  stanford_migrate.overrider:
+    class: Drupal\stanford_migrate\Config\MigrationConfigOverrides
+    arguments: ['@entity_type.manager', '@state']
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/tests/src/Kernel/Config/MigrationConfigOverridesTest.php
+++ b/tests/src/Kernel/Config/MigrationConfigOverridesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\Tests\stanford_migrate\Kernel\Config;
+
+use Drupal\file\Entity\File;
+use Drupal\Tests\stanford_migrate\Kernel\StanfordMigrateKernelTestBase;
+
+/**
+ * Class MigrationConfigOverridesTest.
+ *
+ * @group stanford_migrate
+ * @coversDefaultClass \Drupal\stanford_migrate\Config\MigrationConfigOverrides
+ */
+class MigrationConfigOverridesTest extends StanfordMigrateKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'test_stanford_migrate',
+    'stanford_migrate',
+    'migrate_plus',
+    'migrate',
+    'node',
+    'user',
+    'system',
+    'ultimate_cron',
+    'file'
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('file');
+  }
+
+  /**
+   * After setting the state, the config overrides should set the path data.
+   */
+  public function testConfigOverrides() {
+    $source = \Drupal::configFactory()
+      ->get('migrate_plus.migration.stanford_migrate')
+      ->get('source');
+    $this->assertArrayNotHasKey('path', $source);
+
+    \Drupal::service('file_system')->copy($this->root . '/core/misc/druplicon.png', 'public://example.jpg');
+    $file = File::create([
+      'uri' => 'public://example.jpg',
+    ]);
+    $file->save();
+
+    \Drupal::state()->set('stanford_migrate.csv.stanford_migrate', [$file->id()]);
+    \Drupal::configFactory()->clearStaticCache();
+
+    $source = \Drupal::configFactory()
+      ->get('migrate_plus.migration.stanford_migrate')
+      ->get('source');
+    $this->assertEquals('public://example.jpg', $source['path']);
+  }
+
+}

--- a/tests/src/Kernel/Controller/MigrationCsvTemplateTest.php
+++ b/tests/src/Kernel/Controller/MigrationCsvTemplateTest.php
@@ -36,12 +36,11 @@ class MigrationCsvTemplateTest extends StanfordMigrateKernelTestBase {
    * Migrations that aren't csv importers throw 404 response.
    */
   public function testNotFound() {
-    $migrate_group = MigrationGroup::create([]);
     $migration = Migration::load('stanford_migrate');
     $controller = MigrationCsvTemplate::create(\Drupal::getContainer());
 
     $this->expectException(NotFoundHttpException::class);
-    $controller->getEmptyTemplate($migrate_group, $migration);
+    $controller->getEmptyTemplate($migration);
   }
 
   /**
@@ -55,10 +54,9 @@ class MigrationCsvTemplateTest extends StanfordMigrateKernelTestBase {
       ->set('source.ids', ['guid'])
       ->save();
 
-    $migrate_group = MigrationGroup::create([]);
     $migration = Migration::load('stanford_migrate');
     $controller = MigrationCsvTemplate::create(\Drupal::getContainer());
-    $response = $controller->getEmptyTemplate($migrate_group, $migration);
+    $response = $controller->getEmptyTemplate($migration);
     $this->assertInstanceOf(BinaryFileResponse::class, $response);
     $contents = file_get_contents($response->getFile()->getRealPath());
 

--- a/tests/src/Kernel/Controller/MigrationCsvTemplateTest.php
+++ b/tests/src/Kernel/Controller/MigrationCsvTemplateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\Tests\stanford_migrate\Kernel\Controller;
+
+use Drupal\migrate_plus\Entity\Migration;
+use Drupal\migrate_plus\Entity\MigrationGroup;
+use Drupal\stanford_migrate\Controller\MigrationCsvTemplate;
+use Drupal\Tests\stanford_migrate\Kernel\StanfordMigrateKernelTestBase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Class MigrationCsvTemplateTest.
+ *
+ * @group stanford_migrate
+ * @coversDefaultClass \Drupal\stanford_migrate\Controller\MigrationCsvTemplate
+ */
+class MigrationCsvTemplateTest extends StanfordMigrateKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'test_stanford_migrate',
+    'stanford_migrate',
+    'migrate_plus',
+    'migrate',
+    'node',
+    'user',
+    'system',
+    'ultimate_cron',
+    'migrate_source_csv',
+  ];
+
+  /**
+   * Migrations that aren't csv importers throw 404 response.
+   */
+  public function testNotFound() {
+    $migrate_group = MigrationGroup::create([]);
+    $migration = Migration::load('stanford_migrate');
+    $controller = MigrationCsvTemplate::create(\Drupal::getContainer());
+
+    $this->expectException(NotFoundHttpException::class);
+    $controller->getEmptyTemplate($migrate_group, $migration);
+  }
+
+  /**
+   * The controller should give a csv file with an expected header.
+   */
+  public function testController() {
+    \Drupal::configFactory()
+      ->getEditable('migrate_plus.migration.stanford_migrate')
+      ->set('source.plugin', 'csv')
+      ->set('source.path', '/tmp/foo.csv')
+      ->set('source.ids', ['guid'])
+      ->save();
+
+    $migrate_group = MigrationGroup::create([]);
+    $migration = Migration::load('stanford_migrate');
+    $controller = MigrationCsvTemplate::create(\Drupal::getContainer());
+    $response = $controller->getEmptyTemplate($migrate_group, $migration);
+    $this->assertInstanceOf(BinaryFileResponse::class, $response);
+    $contents = file_get_contents($response->getFile()->getRealPath());
+
+    $this->assertStringContainsString('"guid (GUID)","title (Title)"', $contents);
+  }
+
+}

--- a/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\Tests\stanford_migrate\Kernel\Form;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\migrate_plus\Entity\Migration;
+use Drupal\migrate_plus\Entity\MigrationInterface;
+use Drupal\Tests\stanford_migrate\Kernel\StanfordMigrateKernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class StanfordMigrateCsvImportFormTest.
+ *
+ * @group stanford_migrate
+ * @coversDefaultClass \Drupal\stanford_migrate\Form\StanfordMigrateCsvImportForm
+ */
+class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'test_stanford_migrate',
+    'stanford_migrate',
+    'migrate_plus',
+    'migrate',
+    'node',
+    'user',
+    'system',
+    'ultimate_cron',
+    'file',
+    'migrate_source_csv',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('file');
+  }
+
+  /**
+   * Migrations that aren't csv importers are denied access.
+   */
+  public function testNonCsvAccess() {
+    $this->setMigrationRequest(Migration::load('stanford_migrate'));
+
+    $form_object = \Drupal::entityTypeManager()
+      ->getFormObject('migration', 'csv-upload');
+    $account = $this->createMock(AccountInterface::class);
+    $this->assertFalse($form_object->access($account)->isAllowed());
+  }
+
+  /**
+   * CSV Importers have permission access.
+   */
+  public function testCsvPermissionAccess() {
+    $migration = Migration::load('stanford_migrate');
+    $source = $migration->get('source');
+    $source['plugin'] = 'csv';
+    $source['path'] = '/tmp/tmp.csv';
+    $source['ids'] = ['foo'];
+    $migration->set('source', $source)->save();
+    $this->setMigrationRequest($migration);
+
+    $account = $this->createMock(AccountInterface::class);
+    $form_object = \Drupal::entityTypeManager()
+      ->getFormObject('migration', 'csv-upload');
+    $this->assertFalse($form_object->access($account)->isAllowed());
+
+    $account->method('hasPermission')->willReturn(TRUE);
+    $this->assertTrue($form_object->access($account)->isAllowed());
+  }
+
+  /**
+   * Set the current request on the request stack to have a migration entity.
+   *
+   * @param \Drupal\migrate_plus\Entity\MigrationInterface $migration
+   */
+  protected function setMigrationRequest(MigrationInterface $migration) {
+    $attributes = ['migration' => $migration];
+    $request = new Request([], [], $attributes);
+    \Drupal::requestStack()->push($request);
+  }
+
+}

--- a/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\Tests\stanford_migrate\Kernel\Form;
 
+use Drupal\Core\Form\FormState;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\migrate_plus\Entity\Migration;
+use Drupal\migrate_plus\Entity\MigrationGroup;
 use Drupal\migrate_plus\Entity\MigrationInterface;
 use Drupal\Tests\stanford_migrate\Kernel\StanfordMigrateKernelTestBase;
 use Symfony\Component\HttpFoundation\Request;
@@ -56,13 +58,7 @@ class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
    * CSV Importers have permission access.
    */
   public function testCsvPermissionAccess() {
-    $migration = Migration::load('stanford_migrate');
-    $source = $migration->get('source');
-    $source['plugin'] = 'csv';
-    $source['path'] = '/tmp/tmp.csv';
-    $source['ids'] = ['foo'];
-    $migration->set('source', $source)->save();
-    $this->setMigrationRequest($migration);
+    $this->setCsvMigrationRequest();
 
     $account = $this->createMock(AccountInterface::class);
     $form_object = \Drupal::entityTypeManager()
@@ -73,13 +69,46 @@ class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
     $this->assertTrue($form_object->access($account)->isAllowed());
   }
 
+  public function testBuildForm() {
+    $this->setCsvMigrationRequest();
+    $form = [];
+    $form_state = new FormState();
+    $form_object = \Drupal::entityTypeManager()
+      ->getFormObject('migration', 'csv-upload');
+    $form_object->setEntity(Migration::load('stanford_migrate'));
+
+    $form = $form_object->buildForm($form, $form_state);
+    $this->assertArrayNotHasKey('forget', $form);
+
+    \Drupal::state()->set('stanford_migrate.csv.stanford_migrate', [1, 2, 3]);
+    $form = $form_object->buildForm($form, $form_state);
+    $this->assertArrayHasKey('forget', $form);
+  }
+
+  /**
+   * Modify the migration entity and set it on the current request.
+   */
+  protected function setCsvMigrationRequest() {
+    $migration = Migration::load('stanford_migrate');
+    $source = $migration->get('source');
+    $source['plugin'] = 'csv';
+    $source['path'] = '/tmp/tmp.csv';
+    $source['ids'] = ['foo'];
+    $migration->set('source', $source)->save();
+    $this->setMigrationRequest($migration);
+  }
+
   /**
    * Set the current request on the request stack to have a migration entity.
    *
    * @param \Drupal\migrate_plus\Entity\MigrationInterface $migration
    */
   protected function setMigrationRequest(MigrationInterface $migration) {
-    $attributes = ['migration' => $migration];
+
+    $attributes = [
+      'migration_group' => MigrationGroup::load('stanford_migrate'),
+      'migration' => $migration,
+    ];
     $request = new Request([], [], $attributes);
     \Drupal::requestStack()->push($request);
   }

--- a/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
@@ -41,6 +41,7 @@ class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('file');
+    $this->installSchema('file', ['file_usage']);
   }
 
   /**

--- a/tests/src/Unit/Plugin/Derivative/MigrateLocalTasksTest.php
+++ b/tests/src/Unit/Plugin/Derivative/MigrateLocalTasksTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\Tests\stanford_migrate\Unit\Plugin\Derivative;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\stanford_migrate\Plugin\Derivative\MigrateLocalTasks;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class MigrateLocalTasksTest.
+ *
+ * @group stanford_migrate
+ * @coversDefaultClass \Drupal\stanford_migrate\Plugin\Derivative\MigrateLocalTasks
+ */
+class MigrateLocalTasksTest extends UnitTestCase {
+
+  /**
+   * If the migrate_source_csv module exists.
+   *
+   * @var bool
+   */
+  protected $moduleExists = FALSE;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $module_handler = $this->createMock(ModuleHandlerInterface::class);
+    $module_handler->method('moduleExists')
+      ->willReturnReference($this->moduleExists);
+
+    $container = new ContainerBuilder();
+    $container->set('module_handler', $module_handler);
+
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Local tasks are added when the migrate_source_csv module exists.
+   */
+  public function testLocalTasks() {
+    $deriver = MigrateLocalTasks::create(\Drupal::getContainer(), 'foo');
+    $derivatives = $deriver->getDerivativeDefinitions([]);
+    $this->assertEmpty($derivatives);
+
+    $this->moduleExists = TRUE;
+    $derivatives = $deriver->getDerivativeDefinitions([]);
+    $this->assertArrayHasKey('entity.migration.csv_upload', $derivatives);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Provide a UI form to upload a CSV file for migration entities using the `migrate_source_csv` plugin
- Use config overrides to set the path to the csv that was uploaded.

# Need Review By (Date)
- 4/8

# Urgency
- medium

# Steps to Test
1. Checkout this branch and add `migrate_source_csv` module `composer require drupal/migrate_source_csv; drush en migrate_source_csv`
2. Create a simple csv importer. Heres one you can use:
```
langcode: en
status: true
dependencies: {  }
id: csv_news
class: null
field_plugin_method: null
cck_plugin_method: null
migration_tags: {  }
migration_group: default
label: 'CSV News'
source:
  plugin: csv
  path: /tmp/foo.csv
  constants:
    type: stanford_news
  fields:
    -
      name: id
      label: 'ID *Required'
      selector: id
    -
      name: title
      label: 'Title *Required'
      selector: title
  ids:
    - id
process:
  type: constants/type
  su_news_headline: title
destination:
  plugin: 'entity:node'
migration_dependencies:
  required: {  }
```
4. Navigate to the csv uploader
   - If you are using the example above the path is `/admin/structure/migrate/manage/default/migrations/csv_news/csv-upload`
5. download the template file in help text and populate it with some data
6. upload the file and run the importer using drush or the UI `drush mim csv_news` or `/admin/config/importers`
7. verify your content was created.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
