### PR TITLE
D8CORE-4677 Migrate process plugin to get the OAuth token for use CAP

### DIFF
--- a/src/Plugin/migrate/process/ImageDimensionSkip.php
+++ b/src/Plugin/migrate/process/ImageDimensionSkip.php
@@ -99,7 +99,7 @@ class ImageDimensionSkip extends ProcessPluginBase {
       return FALSE;
     }
     try {
-      [$width, $height] = getimagesize($value);
+      [$width, $height] = @getimagesize($value);
     }
     catch (\Exception $e) {
       return FALSE;

--- a/src/Plugin/migrate/process/OauthAccessToken.php
+++ b/src/Plugin/migrate/process/OauthAccessToken.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\stanford_migrate\Plugin\migrate\process;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\migrate_plus\AuthenticationPluginManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Migrate process plugin that will return the bearer token for OAuth2 auth.
+ *
+ * This requires the migration to be configured for oauth2 authentication, or
+ * pass the oauth2 credentials into the process plugin. The schema for both
+ * are exactly the same.
+ *
+ * @see \Drupal\migrate_plus\Plugin\migrate_plus\authentication\OAuth2
+ *
+ * @MigrateProcessPlugin(
+ *   id = "oauth2_access_token"
+ * )
+ */
+class OauthAccessToken extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Authentication plugin manager service.
+   *
+   * @var \Drupal\migrate_plus\AuthenticationPluginManager
+   */
+  protected $authPluginManager;
+
+  /**
+   * Authentication plugin.
+   *
+   * @var \Drupal\migrate_plus\AuthenticationPluginInterface
+   */
+  protected $authenticationPlugin;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('plugin.manager.migrate_plus.authentication')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, AuthenticationPluginManager $auth_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->authPluginManager = $auth_manager;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $this->configuration += $row->getSource();
+    $options = $this->getAuthenticationPlugin()->getAuthenticationOptions();
+    preg_match('/ .*$/', $options['headers']['Authorization'], $bearer_match);
+    return trim(reset($bearer_match));
+  }
+
+
+  /**
+   * Returns the initialized authentication plugin.
+   *
+   * @return \Drupal\migrate_plus\AuthenticationPluginInterface
+   *   The authentication plugin.
+   */
+  public function getAuthenticationPlugin() {
+    if (!isset($this->authenticationPlugin)) {
+      $this->authenticationPlugin = $this->authPluginManager->createInstance($this->configuration['authentication']['plugin'], $this->configuration['authentication']);
+    }
+    return $this->authenticationPlugin;
+  }
+
+}

--- a/src/Plugin/migrate/process/OauthAccessToken.php
+++ b/src/Plugin/migrate/process/OauthAccessToken.php
@@ -68,7 +68,6 @@ class OauthAccessToken extends ProcessPluginBase implements ContainerFactoryPlug
     return trim(reset($bearer_match));
   }
 
-
   /**
    * Returns the initialized authentication plugin.
    *

--- a/tests/src/Unit/Plugin/migrate/process/OauthAccessTokenTest.php
+++ b/tests/src/Unit/Plugin/migrate/process/OauthAccessTokenTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\Tests\stanford_migrate\Unit\Plugin\migrate\process;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate_plus\AuthenticationPluginInterface;
+use Drupal\migrate_plus\AuthenticationPluginManager;
+use Drupal\stanford_migrate\Plugin\migrate\process\OauthAccessToken;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * class OauthAccessTokenTest.
+ *
+ * @coversDefaultClass \Drupal\stanford_migrate\Plugin\migrate\process\OauthAccessToken
+ */
+class OauthAccessTokenTest extends UnitTestCase {
+
+  /**
+   * Migrate process plugin.
+   *
+   * @var \Drupal\stanford_migrate\Plugin\migrate\process\OauthAccessToken
+   */
+  protected $processPlugin;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $auth_headers = ['headers' => ['Authorization' => 'Bearer foo-bar-baz']];
+    $auth_plugin = $this->createMock(AuthenticationPluginInterface::class);
+    $auth_plugin->method('getAuthenticationOptions')->willReturn($auth_headers);
+
+    $auth_manager = $this->createMock(AuthenticationPluginManager::class);
+    $auth_manager->method('createInstance')->willReturn($auth_plugin);
+    $container = new ContainerBuilder();
+    $container->set('plugin.manager.migrate_plus.authentication', $auth_manager);
+    $this->processPlugin = OauthAccessToken::create($container, [], '', []);
+  }
+
+  /**
+   * The process plugin returns the correct string.
+   */
+  public function testTransform() {
+    $migration = $this->createMock(MigrateExecutableInterface::class);
+    $row = new Row();
+    $row->setSourceProperty('authentication', ['plugin' => 'oauth2']);
+    $this->assertEquals('foo-bar-baz', $this->processPlugin->transform('', $migration, $row, ''));
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Provide a migrate process plugin so that the CAP importer can get the oauth bearer token to append to the image urls.

# Need Review By (Date)
- 11/19

# Urgency
- high

# Steps to Test
1. follow steps in https://github.com/SU-SWS/stanford_profile/pull/467

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
