### PR TITLE
Migrate process plugin to adjust date values to 11:59pm

### DIFF
--- a/src/Plugin/migrate/process/SmartDateAllDayAdjust.php
+++ b/src/Plugin/migrate/process/SmartDateAllDayAdjust.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\stanford_migrate\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Adjust an ending timestamp to work with the "All Day" for smart date module.
+ *
+ * @code
+ * process:
+ *   field_date/end_value:
+ *     plugin: datetime_adjust
+ *     source: end_value
+ *     start_time: start_value
+ * @endcode
+ *
+ * @MigrateProcessPlugin(
+ *   id = "smartdate_adjust"
+ * )
+ */
+class SmartDateAllDayAdjust extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (empty($this->configuration['start_time'])) {
+      return $value;
+    }
+    $start = $row->get($this->configuration['start_time']);
+    if (empty($start)) {
+      return $value;
+    }
+
+    if (!is_numeric($start)) {
+      $start = strtotime($start);
+    }
+
+    if (!is_numeric($value)) {
+      $value = strtotime($value);
+    }
+
+    // If the start and end values are the same & the start is at 12:00 midnight
+    // then increase the end value to be at the end of the day for the smart
+    // date module to work correctly.
+    if ((int) date('Gi', $start) == 0 && $start == $value) {
+      return $value + (60 * 60 * 24) - 60;
+    }
+
+    // If either the start or the end date value are not at midnight, don't
+    // adjust the end value at all since it won't be considered an "All Day"
+    // date time.
+    if ((int) date('Gi', $start) || (int) date('Gi', $value)) {
+      return $value;
+    }
+
+    // Now that the start and the end must both be at midnight and different
+    // days, reduce the end value by 1 minute to work correctly with the smart
+    // date module.
+    return $value - 60;
+  }
+
+}

--- a/tests/src/Unit/Plugin/migrate/process/SmartDateAllDayAdjustTest.php
+++ b/tests/src/Unit/Plugin/migrate/process/SmartDateAllDayAdjustTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\Tests\stanford_migrate\Unit\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate\Row;
+use Drupal\stanford_migrate\Plugin\migrate\process\SmartDateAllDayAdjust;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class SmartDateAllDayAdjust.
+ *
+ * @group stanford_migrate
+ * @coversDefaultClass \Drupal\stanford_migrate\Plugin\migrate\process\SmartDateAllDayAdjust
+ */
+class SmartDateAllDayAdjustTest extends UnitTestCase {
+
+  /**
+   * Test the transform returns an expected hash value.
+   */
+  public function testTranform() {
+    $configuration = [];
+    $definition = [];
+    $plugin = new SmartDateAllDayAdjust($configuration, 'smartdate_adjust', $definition);
+
+    $migrate_executable = $this->createMock(MigrateExecutable::class);
+    $row = $this->createMock(Row::class);
+    $start_value = NULL;
+    $row->method('get')->willReturnReference($start_value);
+
+    // Some regular values and the start time configuration isn't available.
+    $new_value = $plugin->transform(123456, $migrate_executable, $row, '');
+    $this->assertEquals(123456, $new_value);
+
+    // The start time configuration is set, but there's no value for it.
+    $configuration['start_time'] = 'start';
+    $plugin = new SmartDateAllDayAdjust($configuration, 'smartdate_adjust', $definition);
+    $new_value = $plugin->transform(123456, $migrate_executable, $row, '');
+    $this->assertEquals(123456, $new_value);
+
+    // Now the start time exists, but it's not a midnight value.
+    $start_value = 123;
+    $new_value = $plugin->transform(123456, $migrate_executable, $row, '');
+    $this->assertEquals(123456, $new_value);
+
+    // The start and the end values are the exact same, so the end value should
+    // be 23 hours, 59 minutes ahead.
+    $timestamp = strtotime('Jan 10 2020 12:00am');
+    $start_value = date('c', $timestamp);
+    $new_value = $plugin->transform($start_value, $migrate_executable, $row, '');
+    $this->assertEquals($timestamp + 60 * 60 * 24 - 60, $new_value);
+
+    // The end value is midnight of the next day, so it should be adjusted to
+    // 1 minute prior for it to be "all day"
+    $end_timestamp = strtotime('Jan 11 2020 12:00am');
+    $end_value = date('c', $end_timestamp);
+    $new_value = $plugin->transform($end_value, $migrate_executable, $row, '');
+    $this->assertEquals($end_timestamp - 60, $new_value);
+
+    // Start time is midnight, but the end time is at 3PM.
+    $end_timestamp = strtotime('Jan 11 2020 3:00pm');
+    $end_value = date('c', $end_timestamp);
+    $new_value = $plugin->transform($end_value, $migrate_executable, $row, '');
+    $this->assertEquals($end_timestamp, $new_value);
+
+    // Start time is not at midnight, but the end time is.
+    $start_value = date('c', strtotime('Jan 10 2020 8:00am'));
+    $end_timestamp = strtotime('Jan 11 2020 12:00am');
+    $end_value = date('c', $end_timestamp);
+    $new_value = $plugin->transform($end_value, $migrate_executable, $row, '');
+    $this->assertEquals($end_timestamp, $new_value);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Process plugin to convert equal values or midnight values to 11:59pm values.

# Need Review By (Date)
- 1/20/22

# Urgency
- medium

# Steps to Test
1. checkout this branch and the branch in https://github.com/SU-SWS/stanford_profile/pull/474
2. import configs
3. import some events from localist. I used the department "Department of Art & Art History"
4. view one of the nodes
5. validate the date values are checked as "All Day"

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
