### PR TITLE
D8CORE-5193 Add "Forget" orphan action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,21 +47,6 @@ back_to_dev: &back_to_dev
           composer global require SU-SWS/stanford-caravan:dev-8.x-2.x
           ~/.composer/vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY}
 
-d8_codeception: &d8_codeception
-  <<: *defaults
-  steps:
-    - checkout:
-        path: /var/www/test
-    - run:
-        name: Run Codeception Tests
-        command: |
-          composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
-          ~/.composer/vendor/bin/sws-caravan codeception /var/www/html --extension-dir=/var/www/test
-    - store_test_results:
-        path: /var/www/html/artifacts/behat
-    - store_artifacts:
-        path: /var/www/html/artifacts
-
 d9_codeception: &d9_codeception
   <<: *defaults
   steps:
@@ -83,8 +68,6 @@ jobs:
     <<: *code_coverage
   run-back-to-dev:
     <<: *back_to_dev
-  run-d8-codeception:
-    <<: *d8_codeception
   run-d9-codeception:
     <<: *d9_codeception
 
@@ -104,7 +87,6 @@ workflows:
   tests:
     jobs:
       - run-coverage
-      - run-d8-codeception
       - run-d9-codeception
   # Re-test every sunday in case this code becomes stale.
   sundays:

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -15,6 +15,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\migrate\Exception\RequirementsException;
 use Drupal\migrate\MigrateMessage;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Plugin\RequirementsInterface;
 use Drupal\migrate_plus\Entity\Migration;
@@ -83,7 +84,8 @@ function stanford_migrate_get_migration(NodeInterface $node) {
       // If the migrate id map returns something, that means this node is tied
       // to this migration. Set the static variable for later references and
       // get out of here.
-      if (!empty($migrate->getIdMap()->lookupSourceId(['nid' => $node->id()]))) {
+      $row_data = $migrate->getIdMap()->getRowByDestination(['nid' => $node->id()]);
+      if (!empty($row_data) && $row_data['source_row_status'] != MigrateIdMapInterface::STATUS_IGNORED) {
         $node_migration = $migration;
         return $migration;
       }
@@ -112,6 +114,25 @@ function stanford_migrate_entity_field_access($operation, FieldDefinitionInterfa
     // the field.
     foreach (array_keys($columns) as $column) {
       $processing = $processing ?: !empty($migration->process["$field_name/$column"]);
+    }
+
+    // If the migration destination has the `overwrite_properties` configured,
+    // those fields specifically should be locked, not the other fields that
+    // are not designated in the original process configuration.
+    if ($processing && !empty($migration->get('destination')['overwrite_properties'])) {
+      // If the current field doesn't exist in the overwrite_properties, it
+      // should not be considered to be processing since it's a one time only
+      // import.
+      $processing = FALSE;
+
+      foreach ($migration->get('destination')['overwrite_properties'] as $overwrite_property) {
+        // If any part of the field is set to overwrite, lock the whole field
+        // down.
+        $overwrite_property = strstr($overwrite_property, '/', TRUE) ?: $overwrite_property;
+        if ($field_name == $overwrite_property) {
+          $processing = TRUE;
+        }
+      }
     }
 
     if ($processing) {

--- a/tests/src/Kernel/EventSubscriber/EventsSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/EventsSubscriberTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\stanford_migrate\Kernel\EventSubscriber;
 
 use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\Tests\stanford_migrate\Kernel\StanfordMigrateKernelTestBase;
 
 class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
@@ -24,10 +25,10 @@ class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
   public function testEventSubscriber() {
     $migrate = $this->getMigrateExecutable();
     $this->assertEquals(1, $migrate->import());
-    $this->assertEqual(1, $this->getNodeCount());
+    $this->assertEquals(1, $this->getNodeCount());
 
     $migrate->import();
-    $this->assertEqual(1, $this->getNodeCount());
+    $this->assertEquals(1, $this->getNodeCount());
   }
 
   /**
@@ -36,7 +37,7 @@ class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
   public function testDeleteAction() {
     $migrate = $this->getMigrateExecutable();
     $migrate->import();
-    $this->assertEqual(1, $this->getNodeCount());
+    $this->assertEquals(1, $this->getNodeCount());
     \Drupal::configFactory()
       ->getEditable('migrate_plus.migration.stanford_migrate')
       ->set('source.urls', [])
@@ -47,7 +48,7 @@ class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
 
     $migrate = $this->getMigrateExecutable();
     $migrate->import();
-    $this->assertEqual(0, $this->getNodeCount());
+    $this->assertEquals(0, $this->getNodeCount());
   }
 
   /**
@@ -56,7 +57,7 @@ class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
   public function testUnpublishAction() {
     $migrate = $this->getMigrateExecutable();
     $migrate->import();
-    $this->assertEqual(1, $this->getNodeCount());
+    $this->assertEquals(1, $this->getNodeCount());
     \Drupal::configFactory()
       ->getEditable('migrate_plus.migration.stanford_migrate')
       ->set('source.urls', [__DIR__ . '/../test2.xml'])
@@ -67,12 +68,50 @@ class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
 
     $migrate = $this->getMigrateExecutable();
     $migrate->import();
-    $this->assertEqual(2, $this->getNodeCount());
+    $this->assertEquals(2, $this->getNodeCount());
 
     $unpublished_nodes = \Drupal::entityTypeManager()
       ->getStorage('node')
       ->loadByProperties(['status' => 0]);
     $this->assertCount(1, $unpublished_nodes);
+  }
+
+  /**
+   * Forget Orphan action test.
+   */
+  public function testForgetAction() {
+    $migrate = $this->getMigrateExecutable();
+    $migrate->import();
+    $this->assertEquals(1, $this->getNodeCount());
+    \Drupal::configFactory()
+      ->getEditable('migrate_plus.migration.stanford_migrate')
+      ->set('source.urls', [__DIR__ . '/../test2.xml'])
+      ->set('source.orphan_action', 'forget')
+      ->save();
+
+    drupal_flush_all_caches();
+
+    $migrate = $this->getMigrateExecutable();
+    $migrate->import();
+    $this->assertEquals(2, $this->getNodeCount());
+
+    $manager = \Drupal::service('plugin.manager.migration');
+    /** @var \Drupal\migrate\Plugin\Migration $migration */
+    $migration = $manager->createInstance('stanford_migrate');
+    $id_map = $migration->getIdMap();
+    $id_map->rewind();
+
+    $number_ignored = 0;
+    while ($id_map->current()) {
+      $row = $id_map->getRowBySource($id_map->currentSource());
+      if ($row['source_row_status'] == MigrateIdMapInterface::STATUS_IGNORED) {
+        $number_ignored++;
+      }
+      $id_map->next();;
+    }
+    $this->assertGreaterThanOrEqual(2, $id_map->processedCount());
+    $this->assertGreaterThanOrEqual(1, $number_ignored);
+    $this->assertNotEquals($number_ignored, $id_map->processedCount());
   }
 
   /**

--- a/tests/src/Kernel/EventSubscriber/EventsSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/EventsSubscriberTest.php
@@ -93,6 +93,9 @@ class EventsSubscriberTest extends StanfordMigrateKernelTestBase {
 
     $migrate = $this->getMigrateExecutable();
     $migrate->import();
+    drupal_flush_all_caches();
+    $migrate->import();
+    $migrate->import();
     $this->assertEquals(2, $this->getNodeCount());
 
     $manager = \Drupal::service('plugin.manager.migration');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add a forget orphan action for migrations to be ignored after they are no longer in the feed.
- https://github.com/SU-SWS/stanford_profile/pull/475

# Need Review By (Date)
- 1/20

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. Import some events
3. view one of the imported events edit page and see the fields are restricted.
4. set the orphan action for the importer `drush cset migrate_plus.migration.stanford_localist_importer source.orphan_action forget`
5. Change what events should be imported
6. view the original event you looked at and confirm you can now edit all fields.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
