### PR TITLE
Switch form field access to readonly field widget

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "drupal/migrate_tools": "^5.0",
         "drupal/ultimate_cron": "^2.0@alpha",
         "drupal/migrate_source_csv": "^3.4",
-        "joshfraser/php-name-parser": "dev-master"
+        "joshfraser/php-name-parser": "dev-master",
+        "drupal/readonly_field_widget": "^1.4"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     "require": {
         "drupal/migrate_file": "^2.0",
         "drupal/migrate_plus": "^5.0",
-        "drupal/migrate_tools": "^5.0",
-        "drupal/ultimate_cron": "^2.0@alpha",
         "drupal/migrate_source_csv": "^3.4",
-        "joshfraser/php-name-parser": "dev-master",
-        "drupal/readonly_field_widget": "^1.4"
+        "drupal/migrate_tools": "^5.0",
+        "drupal/readonly_field_widget": "^1.4",
+        "drupal/ultimate_cron": "^2.0@alpha",
+        "joshfraser/php-name-parser": "dev-master"
     },
     "extra": {
         "patches": {
@@ -29,6 +29,9 @@
                 "https://www.drupal.org/project/migrate_plus/issues/3050058": "https://www.drupal.org/files/issues/2022-01-03/3050058-9-item-selector-missing.patch"
             }
         }
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {

--- a/css/stanford_migrate.readonly.css
+++ b/css/stanford_migrate.readonly.css
@@ -1,0 +1,5 @@
+.messages.messages--readonly {
+  background-color: transparent;
+  border-color: #ccc;
+  color: inherit;
+}

--- a/stanford_migrate.info.yml
+++ b/stanford_migrate.info.yml
@@ -1,7 +1,7 @@
 name: 'Stanford Migrate'
 description: 'Adds more functionality to migrate and migrate plus modules'
 type: module
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 package: 'Stanford'
 version: 8.x-1.23-dev
 dependencies:

--- a/stanford_migrate.info.yml
+++ b/stanford_migrate.info.yml
@@ -8,4 +8,5 @@ dependencies:
   - drupal:migrate
   - migrate_plus:migrate_plus
   - migrate_tools:migrate_tools
+  - readonly_field_widget:readonly_field_widget
   - ultimate_cron:ultimate_cron

--- a/stanford_migrate.install
+++ b/stanford_migrate.install
@@ -8,6 +8,6 @@
 /**
  * Install readonly_field_widget module.
  */
-function stanford_migrate_update_8001(){
+function stanford_migrate_update_8001() {
   \Drupal::service('module_installer')->install(['readonly_field_widget']);
 }

--- a/stanford_migrate.install
+++ b/stanford_migrate.install
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * stanford_migrate.install
+ */
+
+/**
+ * Install readonly_field_widget module.
+ */
+function stanford_migrate_update_8001(){
+  \Drupal::service('module_installer')->install(['readonly_field_widget']);
+}

--- a/stanford_migrate.libraries.yml
+++ b/stanford_migrate.libraries.yml
@@ -1,0 +1,6 @@
+readonly:
+  css:
+    component:
+      css/stanford_migrate.readonly.css: {}
+  dependencies:
+    - seven/classy.messages

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -147,10 +147,9 @@ function stanford_migrate_entity_form_display_alter(EntityFormDisplayInterface $
 
     if ($processing) {
       \Drupal::messenger()
-        ->addWarning(t('Some fields can not be edited since they contain imported & synced data. They are not visible here.'));
+        ->addWarning(t('Some fields can not be edited since they contain imported & synced data.'));
 
-      // If the default display is configured with some settings, let's use that
-      // for the best display on the entity form.
+      // If the default display is configured with some settings, let's use that      // for the best display on the entity form.
       if ($display_component = $default_display->getComponent($field_name)) {
         $component['settings']['formatter_type'] = $display_component['type'];
         $component['settings']['formatter_settings'] = $display_component['settings'];
@@ -158,6 +157,23 @@ function stanford_migrate_entity_form_display_alter(EntityFormDisplayInterface $
       $component['type'] = 'readonly_field_widget';
       $form_display->setComponent($field_name, $component);
     }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function stanford_migrate_preprocess_field(&$variables) {
+  if (
+    !empty($variables['element']['#parents']) &&
+    in_array('readonly_field', $variables['element']['#parents'])
+  ) {
+    // Wrap the readonly form fields with classes so that they can be identified
+    // more easily to the user.
+    $variables['attributes']['class'][] = 'messages';
+    $variables['attributes']['class'][] = 'messages--warning';
+    $variables['attributes']['class'][] = 'messages--readonly';
+    $variables['#attached']['library'][] = 'stanford_migrate/readonly';
   }
 }
 

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -5,14 +5,12 @@
  * Contains stanford_migrate.module.
  */
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\migrate\Exception\RequirementsException;
 use Drupal\migrate\MigrateMessage;
 use Drupal\migrate\Plugin\MigrateIdMapInterface;
@@ -95,18 +93,30 @@ function stanford_migrate_get_migration(NodeInterface $node) {
 }
 
 /**
- * Implements hook_entity_field_access().
+ * Implements hook_entity_form_display_alter().
  */
-function stanford_migrate_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
-  $route_match = \Drupal::routeMatch();
-  // When edit an existing node that was imported via migrate module, mark the
-  // fields that are mapped from migration as forbidden.
-  if (
-    $operation == 'edit' &&
-    $route_match->getRouteName() == 'entity.node.edit_form' &&
-    $migration = stanford_migrate_get_migration($route_match->getParameter('node'))
-  ) {
-    $field_name = $field_definition->getName();
+function stanford_migrate_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context) {
+  if ($context['entity_type'] != 'node') {
+    return;
+  }
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $migration = stanford_migrate_get_migration($node);
+  // Check if the current node was imported.
+  if (!$migration) {
+    return;
+  }
+  $default_display = EntityViewDisplay::load("node.{$node->bundle()}.default");
+
+  $field_definitions = $form_display->get('fieldDefinitions');
+  foreach ($form_display->getComponents() as $field_name => $component) {
+
+    if (empty($field_definitions[$field_name])) {
+      continue;
+    }
+    $field_definition = $field_definitions[$field_name];
+
+    // When edit an existing node that was imported via migrate module, mark the
+    // fields that are mapped from migration as forbidden.
     $columns = $field_definition->getFieldStorageDefinition()->getColumns();
     $processing = !empty($migration->process[$field_name]);
 
@@ -139,11 +149,16 @@ function stanford_migrate_entity_field_access($operation, FieldDefinitionInterfa
       \Drupal::messenger()
         ->addWarning(t('Some fields can not be edited since they contain imported & synced data. They are not visible here.'));
 
-      return AccessResult::forbidden((string) t('Field is mapped by the importer'));
+      // If the default display is configured with some settings, let's use that
+      // for the best display on the entity form.
+      if ($display_component = $default_display->getComponent($field_name)) {
+        $component['settings']['formatter_type'] = $display_component['type'];
+        $component['settings']['formatter_settings'] = $display_component['settings'];
+      }
+      $component['type'] = 'readonly_field_widget';
+      $form_display->setComponent($field_name, $component);
     }
   }
-
-  return AccessResult::neutral();
 }
 
 /**

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -82,7 +82,8 @@ function stanford_migrate_get_migration(NodeInterface $node) {
       // If the migrate id map returns something, that means this node is tied
       // to this migration. Set the static variable for later references and
       // get out of here.
-      $row_data = $migrate->getIdMap()->getRowByDestination(['nid' => $node->id()]);
+      $row_data = $migrate->getIdMap()
+        ->getRowByDestination(['nid' => $node->id()]);
       if (!empty($row_data) && $row_data['source_row_status'] != MigrateIdMapInterface::STATUS_IGNORED) {
         $node_migration = $migration;
         return $migration;
@@ -96,6 +97,8 @@ function stanford_migrate_get_migration(NodeInterface $node) {
  * Implements hook_entity_form_display_alter().
  */
 function stanford_migrate_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context) {
+  // We only care about nodes, but this could be expanded later if more entities
+  // are imported.
   if ($context['entity_type'] != 'node') {
     return;
   }
@@ -105,18 +108,21 @@ function stanford_migrate_entity_form_display_alter(EntityFormDisplayInterface $
   if (!$migration) {
     return;
   }
+
+  // Grab the default display settings for use later.
   $default_display = EntityViewDisplay::load("node.{$node->bundle()}.default");
 
   $field_definitions = $form_display->get('fieldDefinitions');
   foreach ($form_display->getComponents() as $field_name => $component) {
 
+    // Make sure the field component is one of the field definitions.
     if (empty($field_definitions[$field_name])) {
       continue;
     }
-    $field_definition = $field_definitions[$field_name];
 
     // When edit an existing node that was imported via migrate module, mark the
-    // fields that are mapped from migration as forbidden.
+    // fields that are mapped from migration as readonly.
+    $field_definition = $field_definitions[$field_name];
     $columns = $field_definition->getFieldStorageDefinition()->getColumns();
     $processing = !empty($migration->process[$field_name]);
 
@@ -149,7 +155,9 @@ function stanford_migrate_entity_form_display_alter(EntityFormDisplayInterface $
       \Drupal::messenger()
         ->addWarning(t('Some fields can not be edited since they contain imported & synced data.'));
 
-      // If the default display is configured with some settings, let's use that      // for the best display on the entity form.
+      // If the default display is configured with some settings, let's use that
+      // for the best display on the entity form. If it's not configured, the
+      // readonly_field_widget module will use some default display settings.
       if ($display_component = $default_display->getComponent($field_name)) {
         $component['settings']['formatter_type'] = $display_component['type'];
         $component['settings']['formatter_settings'] = $display_component['settings'];
@@ -325,8 +333,7 @@ function stanford_migrate_ultimate_cron_task(CronJobInterface $cron_entity) {
   if ($migration_group && !empty($migrations[$migration_group])) {
     try {
       array_walk($migrations[$migration_group], 'stanford_migrate_execute_migration');
-    }
-    catch (Exception $e) {
+    } catch (Exception $e) {
 
       // Log any errors that we encounter.
       $logger->error('Unable to run migration importer: @group @message', [
@@ -382,8 +389,7 @@ function stanford_migrate_execute_migration(MigrationInterface $migration, $migr
     $executable = new MigrateExecutable($migration, $log, $options);
     $executable->import();
     $executed_migrations[$migration_id] = $migration_id;
-  }
-  catch (Exception $e) {
+  } catch (Exception $e) {
     \Drupal::logger('stanford_migrate')
       ->critical('Unable to execute importer @id: @message', [
         '@id' => $migration_id,
@@ -420,8 +426,7 @@ function stanford_migrate_migration_list() {
       }
       try {
         $migration->getSourcePlugin()->checkRequirements();
-      }
-      catch (RequirementsException $e) {
+      } catch (RequirementsException $e) {
         \Drupal::logger('stanford_migrate')
           ->error('Unable to execute migration @name: @message', [
             '@name' => $migration->label(),

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -103,10 +103,11 @@ function stanford_migrate_get_migration(NodeInterface $node) {
 function stanford_migrate_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context) {
   // We only care about nodes, but this could be expanded later if more entities
   // are imported.
-  if ($context['entity_type'] != 'node') {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($context['entity_type'] != 'node' || !$node) {
     return;
   }
-  $node = \Drupal::routeMatch()->getParameter('node');
+
   $migration = stanford_migrate_get_migration($node);
   // Check if the current node was imported.
   if (!$migration) {

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -59,16 +59,20 @@ function stanford_migrate_get_migration(NodeInterface $node) {
 
   $plugin_manager = \Drupal::service('plugin.manager.migration');
 
+  // Load only migrations that are enabled.
+  $migrations = \Drupal::entityTypeManager()
+    ->getStorage('migration')
+    ->loadByProperties(['status' => 1]);
+
   // Loop through the migration entities, build their migration plugins so that
   // we can dig into their source mapping data.
   /** @var \Drupal\migrate_plus\Entity\MigrationInterface $migration */
-  foreach (Migration::loadMultiple() as $migration) {
+  foreach ($migrations as $migration) {
 
     // This migrate entity has methods that allow easy queries on the
     // migrate_map tables.
     /** @var \Drupal\migrate\Plugin\MigrationInterface $migrate */
     $migrate = $plugin_manager->createInstance($migration->id());
-
     // CSV Imported content can be ignored since it's normally a one time thing.
     if (!$migrate || $migrate->getSourcePlugin()->getPluginId() == 'csv') {
       continue;

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -333,7 +333,8 @@ function stanford_migrate_ultimate_cron_task(CronJobInterface $cron_entity) {
   if ($migration_group && !empty($migrations[$migration_group])) {
     try {
       array_walk($migrations[$migration_group], 'stanford_migrate_execute_migration');
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
 
       // Log any errors that we encounter.
       $logger->error('Unable to run migration importer: @group @message', [
@@ -389,7 +390,8 @@ function stanford_migrate_execute_migration(MigrationInterface $migration, $migr
     $executable = new MigrateExecutable($migration, $log, $options);
     $executable->import();
     $executed_migrations[$migration_id] = $migration_id;
-  } catch (Exception $e) {
+  }
+  catch (Exception $e) {
     \Drupal::logger('stanford_migrate')
       ->critical('Unable to execute importer @id: @message', [
         '@id' => $migration_id,
@@ -426,7 +428,8 @@ function stanford_migrate_migration_list() {
       }
       try {
         $migration->getSourcePlugin()->checkRequirements();
-      } catch (RequirementsException $e) {
+      }
+      catch (RequirementsException $e) {
         \Drupal::logger('stanford_migrate')
           ->error('Unable to execute migration @name: @message', [
             '@name' => $migration->label(),


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use a module to display the field data instead of hiding everything.

# Need Review By (Date)
- 3/5

# Urgency
- medium

# Steps to Test
1. `composer require drupal/stanford_migrate:dev-readonly_field_widget --no-update`
2. `drush updb -y`
3. import some content (events or people)
4. go to the edit form on one of the imported content
5. verify you see the field data, but can't edit it.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
