### PR TITLE
Override the SQL id_map plugin for our migration lookup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "drupal/ultimate_cron": "^2.0@alpha",
         "joshfraser/php-name-parser": "dev-master"
     },
+    "require-dev": {
+        "drupal/entity_reference_revisions": "^1.9"
+    },
     "extra": {
         "patches": {
             "drupal/migrate_plus": {

--- a/src/Plugin/migrate/id_map/StanfordSql.php
+++ b/src/Plugin/migrate/id_map/StanfordSql.php
@@ -15,6 +15,8 @@ class StanfordSql extends Sql {
   public function getRowByDestination(array $destination_id_values) {
     $query = $this->getDatabase()->select($this->mapTableName(), 'map')
       ->fields('map');
+
+    $conditions = [];
     foreach ($this->destinationIdFields() as $field_name => $destination_id) {
       if (!isset($destination_id_values[$field_name])) {
         // In the parent class, if the destination id values doesn't include
@@ -22,7 +24,13 @@ class StanfordSql extends Sql {
         // whatever values & conditions we can.
         continue;
       }
-      $query->condition("map.$destination_id", $destination_id_values[$field_name], '=');
+      $conditions["map.$destination_id"] = $destination_id_values[$field_name];
+    }
+    if (empty($conditions)) {
+      return [];
+    }
+    foreach ($conditions as $key => $value) {
+      $query->condition($key, $value, '=');
     }
     $result = $query->execute()->fetchAssoc();
     return $result ? $result : [];

--- a/src/Plugin/migrate/id_map/StanfordSql.php
+++ b/src/Plugin/migrate/id_map/StanfordSql.php
@@ -15,8 +15,6 @@ class StanfordSql extends Sql {
   public function getRowByDestination(array $destination_id_values) {
     $query = $this->getDatabase()->select($this->mapTableName(), 'map')
       ->fields('map');
-
-    $conditions = [];
     foreach ($this->destinationIdFields() as $field_name => $destination_id) {
       if (!isset($destination_id_values[$field_name])) {
         // In the parent class, if the destination id values doesn't include
@@ -24,16 +22,10 @@ class StanfordSql extends Sql {
         // whatever values & conditions we can.
         continue;
       }
-      $conditions["map.$destination_id"] = $destination_id_values[$field_name];
+      $query->condition("map.$destination_id", $destination_id_values[$field_name], '=');
     }
-    if (empty($conditions)) {
-      return [];
-    }
-    foreach ($conditions as $key => $value) {
-      $query->condition($key, $value, '=');
-    }
-    $result = $query->execute()->fetchAssoc();
-    return $result ? $result : [];
+    return count($query->conditions()) > 1 ?
+      $query->execute()->fetchAssoc() : [];
   }
 
 }

--- a/src/Plugin/migrate/id_map/StanfordSql.php
+++ b/src/Plugin/migrate/id_map/StanfordSql.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\stanford_migrate\Plugin\migrate\id_map;
+
+use Drupal\migrate\Plugin\migrate\id_map\Sql;
+
+/**
+ * SQL Plugin override to modify the way the methods are used.
+ */
+class StanfordSql extends Sql {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRowByDestination(array $destination_id_values) {
+    $query = $this->getDatabase()->select($this->mapTableName(), 'map')
+      ->fields('map');
+    foreach ($this->destinationIdFields() as $field_name => $destination_id) {
+      if (!isset($destination_id_values[$field_name])) {
+        // In the parent class, if the destination id values doesn't include
+        // every field, we get an empty data. We're overridding it to use
+        // whatever values & conditions we can.
+        continue;
+      }
+      $query->condition("map.$destination_id", $destination_id_values[$field_name], '=');
+    }
+    $result = $query->execute()->fetchAssoc();
+    return $result ? $result : [];
+  }
+
+}

--- a/stanford_migrate.module
+++ b/stanford_migrate.module
@@ -254,6 +254,13 @@ function stanford_migrate_migration_delete(Migration $entity) {
 }
 
 /**
+ * Implements hook_migrate_id_map_info_alter().
+ */
+function stanford_migrate_migrate_id_map_info_alter(&$definitions) {
+  $definitions['sql']['class'] = '\Drupal\stanford_migrate\Plugin\migrate\id_map\StanfordSql';
+}
+
+/**
  * Implements hook_migrate_source_info_alter().
  */
 function stanford_migrate_migrate_source_info_alter(array &$definitions) {

--- a/tests/src/Kernel/Plugin/migrate/id_map/StanfordSqlTest.php
+++ b/tests/src/Kernel/Plugin/migrate/id_map/StanfordSqlTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\Tests\stanford_migrate\Kernel\Plugin\migrate\id_map;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\migrate\MigrateExecutable;
+use Drupal\node\Entity\Node;
+use Drupal\stanford_migrate\Plugin\migrate\id_map\StanfordSql;
+use Drupal\Tests\stanford_migrate\Kernel\StanfordMigrateKernelTestBase;
+
+/**
+ * Class StanfordSqlTest.
+ *
+ * @group stanford_migrate
+ * @coversDefaultClass \Drupal\stanford_migrate\Plugin\migrate\id_map\StanfordSql
+ */
+class StanfordSqlTest extends StanfordMigrateKernelTestBase {
+
+  /**
+   * Ensure the id map returns expected values.
+   */
+  public function testOverride() {
+    \Drupal::configFactory()
+      ->getEditable('migrate_plus.migration.stanford_migrate')
+      ->set('destination.plugin', 'entity_reference_revisions:node')
+      ->set('source.urls', [dirname(__FILE__, 4) . '/test.xml'])
+      ->save();
+    Cache::invalidateTags(['migration_plugins']);
+
+    $manager = \Drupal::service('plugin.manager.migration');
+    /** @var \Drupal\migrate\Plugin\Migration $migration */
+    $migration = $manager->createInstance('stanford_migrate');
+    $migrate_executable = new MigrateExecutable($migration);
+    $migrate_executable->import();
+
+    $nodes = Node::loadMultiple();
+    $node = reset($nodes);
+
+    $this->assertInstanceOf(StanfordSql::class, $migration->getIdMap());
+    $this->assertNotEmpty($migration->getIdMap()
+      ->getRowByDestination(['nid' => $node->id()]));
+    $this->assertNotEmpty($migration->getIdMap()
+      ->getRowByDestination(['nid' => $node->id(), 'vid' => $node->getRevisionId()]));
+    $this->assertEmpty($migration->getIdMap()->getRowByDestination([]));
+  }
+
+}

--- a/tests/src/Kernel/StanfordMigrateKernelTestBase.php
+++ b/tests/src/Kernel/StanfordMigrateKernelTestBase.php
@@ -15,6 +15,7 @@ abstract class StanfordMigrateKernelTestBase extends KernelTestBase {
    */
   protected static $modules = [
     'test_stanford_migrate',
+    'entity_reference_revisions',
     'stanford_migrate',
     'migrate_plus',
     'migrate',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When a migration is configured to import as revisions, once a piece of content is edited it becomes "unlocked". This overrides the id_map method to make each lookup field optional.

# Need Review By (Date)
- asap

# Urgency
- high

# Steps to Test
1. checkout this branch & clear caches
2. import some events
3. edit an event and save with a new revision
4. go back to the edit form
5. verify you still can't edit the fields.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
