### PR TITLE
Add debug_mode and gate "Unable to execute migration" warning behind debug_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Configuration
 
 Nothing special needed.
 
+Debug Mode
+---
+
+This module has a `debug_mode` setting for more verbose logging, disabled by default and only togglable via drush (not exposed on any config form):
+
+```
+drush cset stanford_migrate.settings debug_mode 1
+```
+
+Developers adding new logging to this module should consider gating it behind debug mode if it isn't actionable by default.
+
 
 Troubleshooting
 ---

--- a/config/install/stanford_migrate.settings.yml
+++ b/config/install/stanford_migrate.settings.yml
@@ -1,4 +1,5 @@
 batch_limit: 50
+debug_mode: false
 cron_options:
   default:
     limit: 100

--- a/config/schema/stanford_migrate.schema.yml
+++ b/config/schema/stanford_migrate.schema.yml
@@ -4,6 +4,9 @@ stanford_migrate.settings:
     batch_limit:
       type: integer
       label: "Migration batch limit"
+    debug_mode:
+      type: boolean
+      label: "Debug mode"
     cron_options:
       type: sequence
       label: "Cron Job Options"

--- a/src/StanfordMigrate.php
+++ b/src/StanfordMigrate.php
@@ -5,6 +5,7 @@ namespace Drupal\stanford_migrate;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -67,6 +68,8 @@ class StanfordMigrate implements StanfordMigrateInterface {
    *   Logger factory.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   Default cache service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   Config factory service.
    */
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
@@ -76,6 +79,7 @@ class StanfordMigrate implements StanfordMigrateInterface {
     protected TranslationManager $translation,
     LoggerChannelFactoryInterface $logger_factory,
     protected CacheBackendInterface $cache,
+    protected ConfigFactoryInterface $configFactory,
   ) {
     $this->logger = $logger_factory->get('stanford_migrate');
   }
@@ -157,8 +161,11 @@ class StanfordMigrate implements StanfordMigrateInterface {
       return $migrations;
     }
 
-    $matched_migrations = $this->migrationPluginManager->createInstances(array_keys($this->getMigrationEntities()));
-    // Do not return any migrations which fail to meet requirements.
+    $matched_migrations = $this->migrationPluginManager->createInstances([]);
+    // Do not return any migrations which fail to meet requirements. A failed
+    // requirements check here is routine, not exceptional. Only log when
+    // debug mode is explicitly enabled.
+    $debug_mode = (bool) $this->configFactory->get('stanford_migrate.settings')->get('debug_mode');
     foreach ($matched_migrations as $id => $migration) {
       $source_plugin = $migration->getSourcePlugin();
       if ($source_plugin instanceof RequirementsInterface) {
@@ -166,10 +173,12 @@ class StanfordMigrate implements StanfordMigrateInterface {
           $source_plugin->checkRequirements();
         }
         catch (RequirementsException $e) {
-          $this->logger->error('Unable to execute migration @name: @message', [
-            '@name' => $migration->label(),
-            '@message' => $e->getMessage(),
-          ]);
+          if ($debug_mode) {
+            $this->logger->error('Unable to execute migration @name: @message', [
+              '@name' => $migration->label(),
+              '@message' => $e->getMessage(),
+            ]);
+          }
           unset($matched_migrations[$id]);
         }
       }
@@ -202,7 +211,7 @@ class StanfordMigrate implements StanfordMigrateInterface {
     if ($cache = $this->cache->get($cacheKey)) {
       return $cache->data;
     }
-    $migrations = $this->migrationPluginManager->createInstances(array_keys($this->getMigrationEntities()));
+    $migrations = $this->migrationPluginManager->createInstances([]);
 
     $entity_id = $entity->getEntityType()->get('entity_keys')['id'];
     $entityMigration = NULL;
@@ -278,24 +287,6 @@ class StanfordMigrate implements StanfordMigrateInterface {
         }
       }
     }
-  }
-
-  /**
-   * Get the enabled migration config entities.
-   *
-   * Migration plugins are discovered from every module's migrations/
-   * directory regardless of whether this site has ever configured or
-   * enabled them, so limiting to config entities avoids checking
-   * requirements on, and logging errors about, dormant plugins (e.g.
-   * contrib-bundled D6/D7 upgrade-path migrations) that this site never
-   * opted into.
-   *
-   * @return \Drupal\migrate_plus\Entity\MigrationInterface[]
-   *   Keyed array of enabled migration entities.
-   */
-  protected function getMigrationEntities(): array {
-    $storage = $this->entityTypeManager->getStorage('migration');
-    return $storage->loadByProperties(['status' => 1]);
   }
 
 }

--- a/src/StanfordMigrate.php
+++ b/src/StanfordMigrate.php
@@ -157,7 +157,7 @@ class StanfordMigrate implements StanfordMigrateInterface {
       return $migrations;
     }
 
-    $matched_migrations = $this->migrationPluginManager->createInstances([]);
+    $matched_migrations = $this->migrationPluginManager->createInstances(array_keys($this->getMigrationEntities()));
     // Do not return any migrations which fail to meet requirements.
     foreach ($matched_migrations as $id => $migration) {
       $source_plugin = $migration->getSourcePlugin();
@@ -202,7 +202,7 @@ class StanfordMigrate implements StanfordMigrateInterface {
     if ($cache = $this->cache->get($cacheKey)) {
       return $cache->data;
     }
-    $migrations = $this->migrationPluginManager->createInstances([]);
+    $migrations = $this->migrationPluginManager->createInstances(array_keys($this->getMigrationEntities()));
 
     $entity_id = $entity->getEntityType()->get('entity_keys')['id'];
     $entityMigration = NULL;
@@ -278,6 +278,24 @@ class StanfordMigrate implements StanfordMigrateInterface {
         }
       }
     }
+  }
+
+  /**
+   * Get the enabled migration config entities.
+   *
+   * Migration plugins are discovered from every module's migrations/
+   * directory regardless of whether this site has ever configured or
+   * enabled them, so limiting to config entities avoids checking
+   * requirements on, and logging errors about, dormant plugins (e.g.
+   * contrib-bundled D6/D7 upgrade-path migrations) that this site never
+   * opted into.
+   *
+   * @return \Drupal\migrate_plus\Entity\MigrationInterface[]
+   *   Keyed array of enabled migration entities.
+   */
+  protected function getMigrationEntities(): array {
+    $storage = $this->entityTypeManager->getStorage('migration');
+    return $storage->loadByProperties(['status' => 1]);
   }
 
 }

--- a/stanford_migrate.install
+++ b/stanford_migrate.install
@@ -18,3 +18,13 @@ function stanford_migrate_update_8001() {
 function stanford_migrate_update_8002() {
   \Drupal::service('module_installer')->install(['empty_fields']);
 }
+
+/**
+ * Set the default debug_mode setting explicitly.
+ */
+function stanford_migrate_update_8003() {
+  \Drupal::configFactory()
+    ->getEditable('stanford_migrate.settings')
+    ->set('debug_mode', FALSE)
+    ->save();
+}

--- a/stanford_migrate.services.yml
+++ b/stanford_migrate.services.yml
@@ -3,7 +3,7 @@ services:
     alias: stanford_migrate
   stanford_migrate:
     class: Drupal\stanford_migrate\StanfordMigrate
-    arguments: [ '@entity_type.manager', '@plugin.manager.migration', '@keyvalue', '@datetime.time', '@string_translation', '@logger.factory', '@cache.default' ]
+    arguments: [ '@entity_type.manager', '@plugin.manager.migration', '@keyvalue', '@datetime.time', '@string_translation', '@logger.factory', '@cache.default', '@config.factory' ]
   stanford_migrate.event_subscriber:
     class: Drupal\stanford_migrate\EventSubscriber\EventsSubscriber
     arguments: ['@entity_type.manager', '@logger.factory', '@cache.default']

--- a/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
@@ -67,7 +67,7 @@ class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
     $form_object->validateForm($form, $form_state);
     $this->assertFalse($form_state::hasAnyErrors());
 
-    $file = File::create(['uri' => 'public://foo.csv', 'changed' => \Drupal::time()->getRequestTime()]);
+    $file = File::create(['uri' => 'public://foo.csv']);
     $file->save();
 
     $form['csv']['#parents'] = [];

--- a/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
@@ -68,6 +68,7 @@ class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
     $this->assertFalse($form_state::hasAnyErrors());
 
     $file = File::create(['uri' => 'public://foo.csv']);
+    $file->set('created', time())->set('changed', time())->save();
     $file->save();
 
     $form['csv']['#parents'] = [];

--- a/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
@@ -67,7 +67,7 @@ class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
     $form_object->validateForm($form, $form_state);
     $this->assertFalse($form_state::hasAnyErrors());
 
-    $file = File::create(['uri' => 'public://foo.csv']);
+    $file = File::create(['uri' => 'public://foo.csv', 'changed' => \Drupal::time()->getRequestTime()]);
     $file->save();
 
     $form['csv']['#parents'] = [];

--- a/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
+++ b/tests/src/Kernel/Form/StanfordMigrateCsvImportFormTest.php
@@ -129,6 +129,7 @@ class StanfordMigrateCsvImportFormTest extends StanfordMigrateKernelTestBase {
       'migration' => $migration,
     ];
     $request = new Request([], [], $attributes);
+    $request->server->set('REQUEST_TIME', \Drupal::time()->getRequestTime());
     $session = $this->createMock(SessionInterface::class);
     $request->setSession($session);
     \Drupal::requestStack()->push($request);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- `role_watchdog`'s bundled `d6_role_watchdog` migration (and similar dormant contrib/deriver-based migrations) fails its requirements check every time `getMigrationList()` runs, which happens repeatedly during config saves/imports. `stanford_migrate` logs each of these failures as a watchdog `error()`, producing large amounts of non-actionable log noise (thousands of duplicate entries in a single `suhumsci` deploy).
- Rather than change enumeration/filtering behavior (which we confirmed would break WordPress redirect migrations, since those are derived without a config entity), this PR adds a `debug_mode` config setting. The failure is still silently filtered out of the returned list as before; it's just no longer logged unless `debug_mode` is explicitly enabled.
- `debug_mode` defaults to disabled and is only togglable via drush (`drush cset stanford_migrate.settings debug_mode 1`), not exposed on any config form — intended for developer debugging, not site admins.

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. On a site with a dormant/unconfigured migration plugin enabled (e.g. `role_watchdog`), trigger `getMigrationList()` (config save, entity delete, etc.) and confirm no watchdog error is logged
4. Run `drush cset stanford_migrate.settings debug_mode 1`, repeat step 3, and confirm the error is now logged
5. Confirm existing configured migrations still import/execute/appear in `getMigrationList()` as before
